### PR TITLE
chore(dev-workflow.yml): add optional makeDev input to execute 'make …

### DIFF
--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: '17'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
-      - uses: komune-io/fixers-gradle/.github/actions/setup-gradle-github-pkg@feat/HardforkToKomune
+      - uses: komune-io/fixers-gradle/.github/actions/setup-gradle-github-pkg@main
       - name: Lint
         run: |
           cat ~/.gradle/init.gradle.kts

--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: 'string'
         default: '17'
+      makeDev:
+        description: 'Make Command To Execute'
+        required: false
+        type: 'boolean'
+        default: false
     secrets:
       GPG_SIGNING_KEY:
         required: true
@@ -41,6 +46,9 @@ jobs:
         run: |
           cat ~/.gradle/init.gradle.kts
           make lint
+      - name: Make Dev Up
+        if:  ${{ inputs.makeDev }}
+        run: make dev up
       - name: Build
         run: make build
       - name: Test

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,7 +7,7 @@ on: [push]
 
 jobs:
   call-reusable-workflow:
-    uses: komune-io/fixers-gradle/.github/workflows/dev-workflow.yml@feat/HardforkToKomune
+    uses: komune-io/fixers-gradle/.github/workflows/dev-workflow.yml@main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v2
-      - uses: komune-io/fixers-gradle/.github/actions/setup-gradle-github-pkg@feat/HardforkToKomune
+      - uses: komune-io/fixers-gradle/.github/actions/setup-gradle-github-pkg@main
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v3
 
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
-      - uses: komune-io/fixers-gradle/.github/actions/setup-gradle-github-pkg@feat/HardforkToKomune
+      - uses: komune-io/fixers-gradle/.github/actions/setup-gradle-github-pkg@main
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   call-security-workflow:
-    uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@feat/HardforkToKomune
+    uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}


### PR DESCRIPTION
…dev up' command

The dev-workflow.yml file has been updated to include an optional input called makeDev. When makeDev is set to true, the 'make dev up' command will be executed during the workflow. This allows for easier local development setup by automatically running the necessary commands.