### PR TITLE
fix(sec-workflow.yml): fix typo in workflow name

### DIFF
--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -1,4 +1,4 @@
-ame: Reusable Security Analysis Workflow
+name: Reusable Security Analysis Workflow
 
 on:
   workflow_call:


### PR DESCRIPTION
The typo in the workflow name has been fixed. The name of the workflow is now correctly set to "Reusable Security Analysis Workflow".