### PR TITLE
chore(settings.gradle.kts): update root project name to "fixers-gradl…

### DIFF
--- a/build-composite/settings.gradle.kts
+++ b/build-composite/settings.gradle.kts
@@ -1,3 +1,4 @@
+rootProject.name = "fixers-gradle-build-composite"
 
 dependencyResolutionManagement {
   versionCatalogs {


### PR DESCRIPTION
…e-build-composite"

The root project name has been updated to "fixers-gradle-build-composite" for better clarity and consistency within the project structure.