### PR TITLE
feat(actions): add support for enabling gradle build scan publish in …

### DIFF
--- a/.github/actions/jvm/action.yml
+++ b/.github/actions/jvm/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Flag to initialize Gradle'
     required: false
     default: 'true'
+  with-gradle-build-scan-publish:
+    description: 'Flag to enable gradle build scan publish'
+    required: false
+    default: 'true'
   with-setup-gradle-github-pkg:
     description: 'Flag to set up Gradle with GitHub Packages'
     required: false
@@ -35,6 +39,10 @@ runs:
     - if: inputs.with-gradle == 'true'
       name: Setup Gradle
       uses: gradle/gradle-build-action@v3
+      with:
+        build-scan-publish: ${{ inputs.with-gradle-build-scan-publish }}
+        build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
+        build-scan-terms-of-service-agree: "yes"
     - if: inputs.with-gradle == 'true' || inputs.with-setup-gradle-github-pkg == 'true'
       name: Setup Gradle with GitHub Packages
       id: setup_gradle_github_pkg

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -9,6 +9,12 @@ on:
         type: "string"
         default: "17"
 
+      with-gradle-build-scan-publish:
+        description: "Flag to enable gradle build scan publish"
+        required: false
+        default: true
+        type: "boolean"
+
       make-file:
         description: "The Makefile to execute."
         required: false
@@ -80,6 +86,7 @@ jobs:
       - name: Initialize Java and Gradle Environment
         uses: komune-io/fixers-gradle/.github/actions/jvm@main
         with:
+          with-gradle-build-scan-publish: ${{ inputs.with-gradle-build-scan-publish }}
           java-version: ${{ inputs.java-version }}
 
       - name: Get Version from File

--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -7,12 +7,18 @@ on:
         description: "Java distribution."
         required: false
         type: "string"
-        default: 'temurin'
+        default: "temurin"
       java-version:
-        description: 'Java version'
+        description: "Java version"
         required: false
         type: "string"
-        default: '17'
+        default: "17"
+
+      with-gradle-build-scan-publish:
+        description: "Flag to enable gradle build scan publish"
+        required: false
+        default: true
+        type: "boolean"
 
     secrets:
       SONAR_TOKEN:
@@ -40,6 +46,7 @@ jobs:
         with:
           with-gradle: false
           with-setup-gradle-github-pkg: true
+          with-gradle-build-scan-publish: ${{ inputs.with-gradle-build-scan-publish }}
           java-distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
       - name: Validate Gradle Wrapper
@@ -48,6 +55,9 @@ jobs:
         uses: gradle/actions/dependency-submission@v3
         with:
           additional-arguments: -I ${{ steps.jvm.outputs.setup_gradle_github_pkg }} --no-configuration-cache
+          build-scan-publish: true
+          build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-service-agree: "yes"
 
   sonarcloud-analysis:
     runs-on: ubuntu-latest
@@ -63,12 +73,12 @@ jobs:
       - name: Setup Gradle with GitHub Package Registry for SonarCloud
         uses: komune-io/fixers-gradle/.github/actions/setup-gradle-github-pkg@main
       - name: Run SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@v2
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check SonarQube Quality Gate
-        uses: sonarsource/sonarqube-quality-gate-action@master
+        uses: sonarsource/sonarqube-quality-gate-action@v1.1.0
         timeout-minutes: 5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint-libs:
 	./gradlew detekt
 
 build-libs:
-	./gradlew build --scan
+	./gradlew build
 
 test-libs:
 	./gradlew test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,27 +1,7 @@
 rootProject.name = "fixers-gradle"
 
-pluginManagement {
-	repositories {
-		gradlePluginPortal()
-	}
-}
-
-plugins {
-	id("com.gradle.enterprise") version "3.16.2"
-}
-
 includeBuild("build-composite")
 
 include("config")
 include("dependencies")
 include("plugin")
-
-gradleEnterprise {
-	if (System.getenv("CI") != null) {
-		buildScan {
-			publishAlways()
-			termsOfServiceUrl = "https://gradle.com/terms-of-service"
-			termsOfServiceAgree = "yes"
-		}
-	}
-}


### PR DESCRIPTION
…JVM action

feat(actions): update setup-gradle-github-pkg action to feat/docs branch feat(workflows): update dev workflow to use feat/docs branch for JVM workflow feat(workflows): update make-jvm-workflow to use feat/docs branch for actions feat(workflows): update make-nodejs-workflow to use feat/docs branch for actions feat(workflows): update publish-storybook-workflow to use feat/docs branch for actions The changes were made to enhance the functionality of the actions and workflows by adding support for enabling gradle build scan publish and updating the workflow references to use the feat/docs branch for improved documentation.

feat(sec-workflow.yml): add support for enabling gradle build scan publish feature feat(settings.gradle.kts): remove redundant gradleEnterprise block and simplify build configuration The changes in sec-workflow.yml introduce a new boolean input `with-gradle-build-scan-publish` to enable or disable the gradle build scan publish feature. This provides more flexibility in controlling the behavior of the workflow. In settings.gradle.kts, the gradleEnterprise block is removed as it is redundant and the build configuration is simplified for better readability and maintenance.