### PR TITLE
chore(make-jvm-workflow.yml): remove make-test-env-task and related setup

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -33,12 +33,6 @@ on:
         type: "string"
         default: "build"
 
-      make-test-env-task:
-        description: "The Make command to set up the test environment."
-        required: false
-        type: "string"
-        default: "test"
-
       make-test-task:
         description: "The Make command to execute for testing."
         required: false
@@ -100,12 +94,6 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-build-task }}
-
-      - name: Setup Test Environment and Execute Tests
-        uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
-        with:
-          make-file: ${{ inputs.make-file }}
-          make-step: ${{ inputs.make-test-env-task }}
 
       - name: Execute Make Test Task
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main


### PR DESCRIPTION
The make-test-env-task and its related setup have been removed from the workflow file. This change was made to streamline the workflow and remove unnecessary complexity.