### PR TITLE
build(Makefile): update build-libs target to publish artifacts to Mav…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint-libs:
 	./gradlew detekt
 
 build-libs:
-	./gradlew build
+	./gradlew build publishToMavenLocal -x test
 
 test-libs:
 	./gradlew test
@@ -20,7 +20,7 @@ test-libs:
 	./gradlew test
 
 package-libs: build-libs
-	./gradlew publishToMavenLocal publish
+	./gradlew publish
 
 version:
 	@VERSION=$$(cat VERSION); \


### PR DESCRIPTION
…en local repository

build(package-libs): remove redundant publishToMavenLocal task from package-libs target The build-libs target has been updated to include the publishToMavenLocal task in order to publish the artifacts to the local Maven repository. This change ensures that the locally built artifacts are available for consumption by other projects. Additionally, the redundant publishToMavenLocal task has been removed from the package-libs target to streamline the process and avoid unnecessary duplication of tasks.