### PR TITLE
chore(Makefile): move the definition of VERSION variable to the top o…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: version
+VERSION = $(shell cat VERSION)
 
 lint: lint-libs
 build: build-libs
@@ -23,6 +23,6 @@ publish-libs: build-libs
 promote-libs: build-libs
 	PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
 
+.PHONY: version
 version:
-	@VERSION=$$(cat VERSION); \
 	echo "$$VERSION"


### PR DESCRIPTION
…f the file for better organization

The VERSION variable is now defined at the top of the Makefile for better organization and readability. This change ensures that all variable definitions are grouped together, making it easier for developers to locate and manage them.