### PR TITLE
chore(make-nodejs-workflow.yml): rename version-with-snapshot-sha input to version-with-snapshot-tag and adjust usage accordingly

### DIFF
--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -20,7 +20,7 @@ on:
         default: 'true'
         type: "string"
 
-      version-with-snapshot-sha:
+      version-with-snapshot-tag:
         description: "Base directory of the Node.js project, if applicable."
         required: false
         type: "string"
@@ -125,8 +125,9 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/version@main
         with:
           use-snapshot: false
-          with-snapshot-sha: ${{ inputs.version-with-snapshot-sha }}
           with-main-pre-release-tag: '-alpha-SNAPSHOT'
+          with-release-pre-release-tag: '-alpha-SNAPSHOT'
+          with-snapshot-tag: ${{ inputs.version-with-snapshot-tag }}
 
       - name: Execute Make Lint Task
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main


### PR DESCRIPTION
The input parameter version-with-snapshot-sha has been renamed to version-with-snapshot-tag for better clarity and consistency. The workflow now correctly uses the updated input parameter name in the subsequent steps to ensure proper functionality.