### PR TITLE
chore(make-nodejs-workflow.yml): remove redundant Docker Registry Log…

### DIFF
--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -114,12 +114,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker Registry Login
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Version from File
         uses: komune-io/fixers-gradle/.github/actions/version@main


### PR DESCRIPTION
…in step

The Docker Registry Login step was redundant as the login action was already performed earlier in the workflow. Removing this step simplifies the workflow and reduces unnecessary duplication.