### PR TITLE
chore(build): remove redundant mavenJava publication in publishing_plugin.gradle

### DIFF
--- a/config/build.gradle.kts
+++ b/config/build.gradle.kts
@@ -3,3 +3,9 @@ plugins {
 }
 
 apply(from = rootProject.file("gradle/publishing_module.gradle"))
+
+project.plugins.withId("java-gradle-plugin") { // only do it if it's actually applied
+    project.configure<GradlePluginDevelopmentExtension> {
+        isAutomatedPublishing = false
+    }
+}

--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -3,3 +3,9 @@ plugins {
 }
 
 apply(from = rootProject.file("gradle/publishing_module.gradle"))
+
+project.plugins.withId("java-gradle-plugin") { // only do it if it's actually applied
+    project.configure<GradlePluginDevelopmentExtension> {
+        isAutomatedPublishing = false
+    }
+}

--- a/gradle/publishing_module.gradle
+++ b/gradle/publishing_module.gradle
@@ -19,9 +19,6 @@ afterEvaluate { Project project ->
                 artifact javadocJar
                 pom.withXml(configureMavenCentralMetadata)
             }
-            pluginMaven(MavenPublication) {
-                pom.withXml(configureMavenCentralMetadata)
-            }
         }
         repositories {
             maven {

--- a/gradle/publishing_plugin.gradle
+++ b/gradle/publishing_plugin.gradle
@@ -13,10 +13,6 @@ apply from: project.rootProject.file('gradle/publishing_common.gradle')
 afterEvaluate { Project project ->
     publishing {
         publications {
-            mavenJava(MavenPublication) {
-                from components.java
-                pom.withXml(configureMavenCentralMetadata)
-            }
             pluginMaven(MavenPublication) {
                 pom.withXml(configureMavenCentralMetadata)
             }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
 	`kotlin-dsl`
-	kotlin("jvm")
 	id("com.gradle.plugin-publish")
 }
 


### PR DESCRIPTION
The mavenJava publication was removed from the publishing_plugin.gradle file as it was redundant and not being used. This cleanup improves the clarity and maintainability of the build configuration.