### PR TITLE
fix(PublishPlugin.kt): update environment variable names for GPG signing key and password for clarity and consistency

### DIFF
--- a/plugin/src/main/kotlin/io/komune/fixers/gradle/publish/PublishPlugin.kt
+++ b/plugin/src/main/kotlin/io/komune/fixers/gradle/publish/PublishPlugin.kt
@@ -49,8 +49,8 @@ class PublishPlugin : Plugin<Project> {
 	}
 
 	private fun Project.setupSign() {
-		val inMemoryKey = getenv("signingKey") ?: findProperty("signingKey")?.toString()
-		val password = getenv("signingPassword") ?: findProperty("signingPassword")?.toString()
+		val inMemoryKey = getenv("GPG_SIGNING_KEY") ?: findProperty("GPG_SIGNING_KEY")?.toString()
+		val password = getenv("GPG_SIGNING_PASSWORD") ?: findProperty("GPG_SIGNING_PASSWORD")?.toString()
 		if (inMemoryKey == null) {
 			logger.warn("No signing config provided, skip signing")
 			return


### PR DESCRIPTION
The environment variable names for the GPG signing key and password have been updated to be more descriptive and consistent with the naming conventions. This change improves clarity and maintainability of the code related to GPG signing configuration.