### PR TITLE
ci(make-nodejs-workflow.yml): add make-promote-task-condition input to control when to execute the Make Promote Task

### DIFF
--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -60,6 +60,12 @@ on:
         type: "string"
         default: "publish"
 
+      make-promote-task-condition:
+        description: "The Make command to execute for promoting."
+        required: false
+        type: "boolean"
+        default: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+
       make-promote-task:
         description: "The Make command to execute for promoting."
         required: false
@@ -149,7 +155,7 @@ jobs:
           npm-auth-token: ${{ secrets.NPM_PKG_NPMJS_TOKEN }}
           npm-registry: registry.npmjs.org
       - name: Execute Make Promote Task
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+        if: inputs.make-promote-task-condition
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}


### PR DESCRIPTION
The make-promote-task-condition input has been added to the workflow file to provide more flexibility in determining when to execute the Make Promote Task. This condition allows the task to be executed based on the value of the input, which is set to true when the GitHub reference is 'refs/heads/main' or starts with 'refs/heads/release/'. This change enhances the control over the workflow execution based on specific conditions.