### PR TITLE
ci(make-nodejs-workflow.yml): add make-promote-task-condition input to control when to execute the Make Promote Task

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@feat/release
     permissions:
       contents: read
       packages: write
@@ -17,7 +17,7 @@ jobs:
       PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
 
   docs:
-    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@feat/release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -60,6 +60,12 @@ on:
         type: "string"
         default: "publish"
 
+      make-promote-task-condition:
+        description: "The Make command to execute for promoting."
+        required: false
+        type: "boolean"
+        default: true
+
       make-promote-task:
         description: "The Make command to execute for promoting."
         required: false
@@ -149,7 +155,7 @@ jobs:
           npm-auth-token: ${{ secrets.NPM_PKG_NPMJS_TOKEN }}
           npm-registry: registry.npmjs.org
       - name: Execute Make Promote Task
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+        if: inputs.make-promote-task-condition || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@feat/release
     with:
       make-file: "docs.mk"
       base-dir: ${{ inputs.storybook-dir }}


### PR DESCRIPTION
The make-promote-task-condition input has been added to the workflow file to provide more flexibility in determining when to execute the Make Promote Task. This condition allows the task to be executed based on the value of the input, which is set to true when the GitHub reference is 'refs/heads/main' or starts with 'refs/heads/release/'. This change enhances the control over the workflow execution based on specific conditions.