### PR TITLE
chore(dev.yml): update workflow references to use the 'main' branch instead of 'feat/release'

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@feat/release
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
     permissions:
       contents: read
       packages: write
@@ -17,7 +17,7 @@ jobs:
       PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
 
   docs:
-    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@feat/release
+    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@feat/release
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@main
     with:
       make-file: "docs.mk"
       base-dir: ${{ inputs.storybook-dir }}


### PR DESCRIPTION
chore(publish-storybook-workflow.yml): update workflow reference to use the 'main' branch instead of 'feat/release'

The changes were made to update the workflow references to use the 'main' branch instead of the 'feat/release' branch. This ensures consistency and aligns with the standard branch naming conventions.