### PR TITLE
chore(version): add with-versioning-pre-release-tag input to action.yml for consistency

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Pre-release tag for refactoring branches."
     required: false
     default: "-dev"
+  with-versioning-pre-release-tag:
+    description: "Pre-release tag for refactoring branches."
+    required: false
+    default: "-dev"
 
 outputs:
   VERSION:
@@ -52,7 +56,7 @@ runs:
         IFS=' ' read -r -a BRANCH_PREFIXES <<< "${{ inputs.branch-prefixes }}"
         echo "Parsed BRANCH_PREFIXES: ${BRANCH_PREFIXES[@]}"
 
-        TAGS=("${{ inputs.with-main-pre-release-tag }}" "${{ inputs.with-release-pre-release-tag }}" "${{ inputs.with-feat-pre-release-tag }}" "${{ inputs.with-fix-pre-release-tag }}" "${{ inputs.with-refact-pre-release-tag }}")
+        TAGS=("${{ inputs.with-main-pre-release-tag }}" "${{ inputs.with-release-pre-release-tag }}" "${{ inputs.with-feat-pre-release-tag }}" "${{ inputs.with-fix-pre-release-tag }}" "${{ inputs.with-refact-pre-release-tag }}" "${{ inputs.with-versioning-pre-release-tag }}")
         echo "TAGS array: ${TAGS[@]}"
 
         for ((i=0; i<${#BRANCH_PREFIXES[@]}; i++)); do


### PR DESCRIPTION
The with-versioning-pre-release-tag input was added to the action.yml file to maintain consistency with other pre-release tag inputs. This change ensures that all pre-release tags follow the same pattern and are easily configurable.