### PR TITLE
feat(action.yml): add support for a default tag to use if the specific branch tag is empty

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -33,11 +33,15 @@ inputs:
   with-refact-pre-release-tag:
     description: "Pre-release tag for refactoring branches."
     required: false
-    default: "-dev"
+    default: "-dev-SNAPSHOT"
   with-versioning-pre-release-tag:
     description: "Pre-release tag for refactoring branches."
     required: false
-    default: "-dev"
+    default: "-dev-SNAPSHOT"
+  with-default-tag:
+    description: "Default tag to use if the specific branch tag is empty."
+    required: false
+    default: "-dev-SNAPSHOT"
 
 outputs:
   VERSION:
@@ -56,14 +60,17 @@ runs:
         IFS=' ' read -r -a BRANCH_PREFIXES <<< "${{ inputs.branch-prefixes }}"
         echo "Parsed BRANCH_PREFIXES: ${BRANCH_PREFIXES[@]}"
 
-        TAGS=("${{ inputs.with-main-pre-release-tag }}" "${{ inputs.with-release-pre-release-tag }}" "${{ inputs.with-feat-pre-release-tag }}" "${{ inputs.with-fix-pre-release-tag }}" "${{ inputs.with-refact-pre-release-tag }}" "${{ inputs.with-versioning-pre-release-tag }}")
+        TAGS=("${{ inputs.with-main-pre-release-tag }}" "${{ inputs.with-release-pre-release-tag }}" "${{ inputs.with-feat-pre-release-tag }}" "${{ inputs.with-fix-pre-release-tag }}" "${{ inputs.with-refact-pre-release-tag }}")
         echo "TAGS array: ${TAGS[@]}"
 
         for ((i=0; i<${#BRANCH_PREFIXES[@]}; i++)); do
           echo "Checking branch prefix: ${BRANCH_PREFIXES[i]}"
           if [[ "${{ github.ref }}" == "refs/heads/${BRANCH_PREFIXES[i]}"* ]]; then
             echo "Match found: ${BRANCH_PREFIXES[i]}"
-            VERSION=${VERSION/-SNAPSHOT/${TAGS[i]}}
+            # Use the specific tag if available; otherwise, use the default tag from inputs
+            TAG_TO_USE="${TAGS[i]:-${{ inputs.with-default-tag }}}"
+            echo "Tag to use: $TAG_TO_USE"
+            VERSION=${VERSION/-SNAPSHOT/$TAG_TO_USE}
             echo "Updated VERSION: $VERSION"
             echo "$VERSION" > VERSION
             break


### PR DESCRIPTION
The default tag "-dev-SNAPSHOT" is now used as a fallback when a specific branch tag is not provided. This enhancement ensures that a default tag is always available for use in the versioning process, improving consistency and reliability.