### PR TITLE
style(version): update echo statement to include the current branch prefix being checked

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -64,7 +64,7 @@ runs:
         echo "TAGS array: ${TAGS[@]}"
 
         for ((i=0; i<${#BRANCH_PREFIXES[@]}; i++)); do
-          echo "Checking branch prefix: ${BRANCH_PREFIXES[i]}"
+          echo "Checking branch prefix: ${{github.ref}} == ${BRANCH_PREFIXES[i]}"
           if [[ "${{ github.ref }}" == "refs/heads/${BRANCH_PREFIXES[i]}"* ]]; then
             echo "Match found: ${BRANCH_PREFIXES[i]}"
             # Use the specific tag if available; otherwise, use the default tag from inputs


### PR DESCRIPTION
The echo statement in the script has been updated to include the current branch prefix being checked along with the value of ${{github.ref}}. This change improves the readability of the output and provides more context when the script is running.