### PR TITLE
refactor(version): update branch prefix check message to include the …

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -72,7 +72,7 @@ runs:
         echo "TAGS array: ${TAGS[@]}"
 
         for ((i=0; i<${#BRANCH_PREFIXES[@]}; i++)); do
-          echo "Checking branch prefix: ${{github.ref}} == ${BRANCH_PREFIXES[i]}"
+          echo "Checking branch prefix: $BRANCH_NAME == refs/heads/${BRANCH_PREFIXES[i]}"
           if [[ "$BRANCH_NAME" == "refs/heads/${BRANCH_PREFIXES[i]}"* ]]; then
             echo "Match found: ${BRANCH_PREFIXES[i]}"
             # Use the specific tag if available; otherwise, use the default tag from inputs


### PR DESCRIPTION
…full branch name

The message for checking branch prefixes has been updated to include the full branch name (refs/heads/) along with the branch prefix being checked. This change improves clarity and makes it easier to understand which branch prefixes are being compared against the current branch name.