### PR TITLE
fix(gradle): update detekt version to 1.23.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-detekt = "1.23.5"
+detekt = "1.23.6"
 kotlin = "1.9.22"
 dokka = "1.9.10"
 java = "11"


### PR DESCRIPTION
The detekt version has been updated to 1.23.6 to ensure that the latest features, improvements, and bug fixes are incorporated into the project.