### PR TITLE
feat(make-jvm-workflow.yml): add support for Docker login to the Docker registry

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -15,6 +15,12 @@ on:
         default: true
         type: "boolean"
 
+      with-docker-registry-login:
+        description: 'Flag to enable Docker login to the Docker registry.'
+        required: false
+        default: 'false'
+        type: "string"
+
       make-file:
         description: "The Makefile to execute."
         required: false
@@ -112,6 +118,14 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-test-task }}
+
+      - if: inputs.with-docker-registry-login == 'true'
+        name: Docker Registry Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Execute Make Publish Task
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish'))


### PR DESCRIPTION
The workflow file now includes a new input parameter 'with-docker-registry-login' which is a flag to enable Docker login to the Docker registry. When this flag is set to 'true', a step for Docker registry login is executed using the docker/login-action@v3 GitHub Action. This enhancement allows for seamless integration with Docker registries for the workflow when needed.