### PR TITLE
chore(publish-storybook-workflow.yml): update default value of with-setup-npm-github-pkg to 'true'

### DIFF
--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -16,7 +16,7 @@ on:
       with-setup-npm-github-pkg:
         description: 'Flag to enable Npm setup with GitHub Packages.'
         required: false
-        default: 'false'
+        default: 'true'
         type: "string"
 
       storybook-dir:


### PR DESCRIPTION
The default value of the with-setup-npm-github-pkg flag has been updated to 'true' to enable Npm setup with GitHub Packages by default. This change ensures that the workflow is consistent with the desired configuration.