### PR TITLE
chore(dev.yml): update PKG_GITHUB_USERNAME to use github.actor and PKG_GITHUB_TOKEN to use secrets.GITHUB_TOKEN for better security

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,8 +17,8 @@ jobs:
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
-      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ github.actor }}
+      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
       PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
 


### PR DESCRIPTION
The PKG_GITHUB_USERNAME now uses the github.actor variable, which provides the username of the GitHub Actions bot running the workflow. This change ensures that the correct GitHub username is used consistently. Additionally, the PKG_GITHUB_TOKEN now uses the predefined secrets.GITHUB_TOKEN instead of a custom secret, which is a best practice for security reasons.