### PR TITLE
chore(make-jvm-workflow.yml): add optional parameter for specifying target platforms in Docker buildx

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -134,6 +134,7 @@ jobs:
           make-step: ${{ inputs.make-lint-task }}
 
       - if: inputs.docker-buildx-platform != ''
+        name: Setup Docker Buildx for Specified Platforms
         uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{ inputs.docker-buildx-platform }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -57,14 +57,19 @@ on:
         type: "string"
         default: "promote"
 
+      docker-buildx-platform:
+        description: "Specify the target platforms for Docker buildx, such as 'linux/amd64,linux/arm64'. Leave empty to use the default platform."
+        required: false
+        type: "string"
+
       docker-publish-repository:
-        description: ""
+        description: "The Docker registry to which images should be published. Defaults to GitHub Container Registry (ghcr.io)."
         required: false
         type: "string"
         default: "ghcr.io"
 
       docker-promote-repository:
-        description: ""
+        description: "The Docker registry to which images should be promoted. Defaults to Docker Hub (docker.io)."
         required: false
         type: "string"
         default: "docker.io"
@@ -78,6 +83,7 @@ on:
         description: "The path to the artifact to upload, if needed."
         required: false
         type: "string"
+
     secrets:
       GPG_SIGNING_KEY:
         required: true
@@ -126,6 +132,11 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-lint-task }}
+
+      - if: inputs.docker-buildx-platform != ''
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ inputs.docker-buildx-platform }}
 
       - name: Execute Make Build Task
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main


### PR DESCRIPTION
chore(make-jvm-workflow.yml): update descriptions for docker-publish-repository and docker-promote-repository
feat(make-jvm-workflow.yml): introduce the ability to specify target platforms for Docker buildx by adding the docker-buildx-platform parameter. This allows users to define the target platforms for the Docker buildx process, enhancing flexibility in building and publishing images for different architectures. Additionally, the descriptions for docker-publish-repository and docker-promote-repository have been updated for clarity and consistency.