### PR TITLE
chore(make-jvm-workflow.yml): update required fields for secrets to be optional

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -86,9 +86,9 @@ on:
 
     secrets:
       GPG_SIGNING_KEY:
-        required: true
+        required: false
       GPG_SIGNING_PASSWORD:
-        required: true
+        required: false
       PKG_GITHUB_USERNAME:
         required: false
       PKG_GITHUB_TOKEN:
@@ -102,9 +102,9 @@ on:
       DOCKER_PROMOTE_PASSWORD:
         required: false
       PKG_SONATYPE_OSS_USERNAME:
-        required: true
+        required: false
       PKG_SONATYPE_OSS_TOKEN:
-        required: true
+        required: false
 
 jobs:
   run-dev-tasks:


### PR DESCRIPTION
The required fields for secrets in the make-jvm-workflow.yml file have been updated to be optional (required: false). This change allows for more flexibility in the workflow configuration, as these secrets are no longer mandatory for the workflow to run successfully.