### PR TITLE
ci: add reusable JVM development workflow for Kotlin-NPM projects

### DIFF
--- a/.github/workflows/make-kotlin-npm-workflow.yml
+++ b/.github/workflows/make-kotlin-npm-workflow.yml
@@ -1,0 +1,153 @@
+name: Reusable JVM Development Workflow
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: "The Java version to use."
+        required: false
+        type: "string"
+        default: "17"
+
+      with-gradle-build-scan-publish:
+        description: "Flag to enable gradle build scan publish"
+        required: false
+        default: true
+        type: "boolean"
+
+      make-file:
+        description: "The Makefile to execute."
+        required: false
+        type: "string"
+        default: "Makefile"
+
+      make-lint-task:
+        description: "The Make command to execute for linting."
+        required: false
+        type: "string"
+        default: "lint"
+
+      make-build-task:
+        description: "The Make command to execute for building."
+        required: false
+        type: "string"
+        default: "build"
+
+      make-test-task:
+        description: "The Make command to execute for testing."
+        required: false
+        type: "string"
+        default: "test"
+
+      make-publish-task:
+        description: "The Make command to execute for publishing."
+        required: false
+        type: "string"
+        default: "publish"
+
+      make-promote-task:
+        description: "The Make command to execute for promote."
+        required: false
+        type: "string"
+        default: "promote"
+
+      artifact-name:
+        description: "The name for the uploaded artifact, if needed."
+        required: false
+        type: "string"
+
+      artifact-path:
+        description: "The path to the artifact to upload, if needed."
+        required: false
+        type: "string"
+
+      version-with-snapshot-tag:
+        description: "Base directory of the Node.js project, if applicable."
+        required: false
+        type: "string"
+        default: ".${GITHUB_SHA:0:7}"
+
+    secrets:
+      PKG_GITHUB_USERNAME:
+        required: false
+      PKG_GITHUB_TOKEN:
+        required: false
+      NPM_PKG_PUBLISH_TOKEN:
+        required: false
+      NPM_PKG_PROMOTE_TOKEN:
+        required: false
+
+jobs:
+  run-dev-tasks:
+    runs-on: ubuntu-latest
+    env:
+      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
+      PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
+      PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize Java and Gradle Environment
+        uses: komune-io/fixers-gradle/.github/actions/jvm@main
+        with:
+          with-gradle-build-scan-publish: ${{ inputs.with-gradle-build-scan-publish }}
+          java-version: ${{ inputs.java-version }}
+
+      - name: Get Version from File
+        uses: komune-io/fixers-gradle/.github/actions/version@main
+        with:
+          use-snapshot: false
+          with-main-pre-release-tag: '-alpha-SNAPSHOT'
+          with-release-pre-release-tag: '-alpha-SNAPSHOT'
+          with-snapshot-tag: ${{ inputs.version-with-snapshot-tag }}
+
+      - name: Execute Make Lint Task
+        uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
+        with:
+          make-file: ${{ inputs.make-file }}
+          make-step: ${{ inputs.make-lint-task }}
+
+      - if: inputs.docker-buildx-platform != ''
+        name: Setup Docker Buildx for Specified Platforms
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ inputs.docker-buildx-platform }}
+
+      - name: Execute Make Build Task
+        uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
+        with:
+          make-file: ${{ inputs.make-file }}
+          make-step: ${{ inputs.make-build-task }}
+
+      - name: Execute Make Test Task
+        uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
+        with:
+          make-file: ${{ inputs.make-file }}
+          make-step: ${{ inputs.make-test-task }}
+
+      - name: Execute Make Publish Task
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish'))
+        uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
+        with:
+          make-file: ${{ inputs.make-file }}
+          make-step: ${{ inputs.make-publish-task }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_PKG_PUBLISH_TOKEN }}
+
+      - name: Execute Make Promote Task
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+        uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
+        with:
+          make-file: ${{ inputs.make-file }}
+          make-step: ${{ inputs.make-promote-task }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_PKG_PROMOTE_TOKEN }}
+
+      - name: Upload Artifact if Specified
+        if: inputs.artifact-name != '' && inputs.artifact-path != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}

--- a/config/src/main/kotlin/io/komune/gradle/config/model/Npm.kt
+++ b/config/src/main/kotlin/io/komune/gradle/config/model/Npm.kt
@@ -2,7 +2,7 @@ package io.komune.gradle.config.model
 
 data class Npm(
 	var publish: Boolean = true,
-	var organization: String = "komune",
+	var organization: String = "komune-io",
 	var clean: Boolean = true,
 	var version: String? = null,
 )


### PR DESCRIPTION
feat: update Npm organization field to "komune-io" for consistency The new GitHub workflow file provides a reusable development workflow for JVM projects that use Kotlin and NPM. It allows customization of Java version, build tasks, and artifact publishing. The Npm organization field in the Npm data class is updated to "komune-io" for consistency with the organization naming convention.