### PR TITLE
chore(make-nodejs-workflow.yml): add support for specifying Docker registry for publishing and promoting images, as well as target platforms for Docker buildx

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -152,7 +152,7 @@ jobs:
           make-step: ${{ inputs.make-test-task }}
 
       - if: (inputs.with-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish'))))
-        name: Docker Registry Login
+        name: Docker Registry Login to Publish
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.docker-publish-repository }}
@@ -167,7 +167,7 @@ jobs:
           make-step: ${{ inputs.make-publish-task }}
 
       - if: (inputs.with-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
-        name: Docker Registry Login
+        name: Docker Registry Login To Promote
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.docker-promote-repository }}

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -54,23 +54,11 @@ on:
         type: "string"
         default: "test"
 
-      make-publish-task-condition:
-        description: "The Make command to execute for promoting."
-        required: false
-        type: "boolean"
-        default: true
-
       make-publish-task:
         description: "The Make command to execute for publishing."
         required: false
         type: "string"
         default: "publish"
-
-      make-promote-task-condition:
-        description: "The Make command to execute for promoting."
-        required: false
-        type: "boolean"
-        default: true
 
       make-promote-task:
         description: "The Make command to execute for promoting."
@@ -183,7 +171,7 @@ jobs:
           make-step: ${{ inputs.make-test-task }}
 
       - if: (inputs.with-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish'))))
-        name: Docker Registry Login
+        name: Docker Registry Login to Publish
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.docker-publish-repository }}
@@ -191,15 +179,14 @@ jobs:
           password: ${{ secrets.DOCKER_PUBLISH_PASSWORD }}
 
       - name: Execute Make Publish Task
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish'))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
-        if: inputs.make-publish-task-condition || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'publish')
-
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-publish-task }}
 
       - if: (inputs.with-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
-        name: Docker Registry Login
+        name: Docker Registry Login To Promote
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.docker-promote-repository }}
@@ -213,6 +200,7 @@ jobs:
         with:
           npm-auth-token: ${{ secrets.NPM_PKG_NPMJS_TOKEN }}
           npm-registry: registry.npmjs.org
+
       - name: Execute Make Promote Task
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
@@ -220,8 +208,7 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-promote-task }}
 
-
-      - name: Upload Artifact If Specified
+      - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -78,6 +78,23 @@ on:
         type: "string"
         default: "promote"
 
+      docker-publish-repository:
+        description: "The Docker registry to which images should be published. Defaults to GitHub Container Registry (ghcr.io)."
+        required: false
+        type: "string"
+        default: "ghcr.io"
+
+      docker-promote-repository:
+        description: "The Docker registry to which images should be promoted. Defaults to Docker Hub (docker.io)."
+        required: false
+        type: "string"
+        default: "docker.io"
+
+      docker-buildx-platform:
+        description: "Specify the target platforms for Docker buildx, such as 'linux/amd64,linux/arm64'. Leave empty to use the default platform."
+        required: false
+        type: "string"
+
       artifact-name:
         description: "The name for the uploaded artifact, if needed."
         required: false
@@ -89,6 +106,14 @@ on:
         type: "string"
 
     secrets:
+      DOCKER_PUBLISH_USERNAME:
+        required: false
+      DOCKER_PUBLISH_PASSWORD:
+        required: false
+      DOCKER_PROMOTE_USERNAME:
+        required: false
+      DOCKER_PROMOTE_PASSWORD:
+        required: false
       NPM_PKG_GITHUB_TOKEN:
         required: false
       NPM_PKG_NPMJS_TOKEN:
@@ -109,12 +134,14 @@ jobs:
         with:
           base-dir: ${{ inputs.base-dir }}
           node-version: ${{ inputs.node-version }}
+
       - if: inputs.with-setup-npm-github-pkg == 'true'
         name: Setup Npm with GitHub Packages
         id: setup_npm_github_pkg
         uses: komune-io/fixers-gradle/.github/actions/setup-npm-github-pkg@main
         with:
           npm-auth-token: ${{ secrets.NPM_PKG_GITHUB_TOKEN }}
+
       - if: inputs.with-docker-registry-login == 'true'
         name: Docker Registry Login
         uses: docker/login-action@v3
@@ -137,6 +164,12 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-lint-task }}
 
+      - if: inputs.docker-buildx-platform != ''
+        name: Setup Docker Buildx for Specified Platforms
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ inputs.docker-buildx-platform }}
+
       - name: Execute Make Build Task
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
@@ -149,6 +182,14 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-test-task }}
 
+      - if: (inputs.with-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish'))))
+        name: Docker Registry Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.docker-publish-repository }}
+          username: ${{ secrets.DOCKER_PUBLISH_USERNAME }}
+          password: ${{ secrets.DOCKER_PUBLISH_PASSWORD }}
+
       - name: Execute Make Publish Task
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         if: inputs.make-publish-task-condition || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'publish')
@@ -156,6 +197,15 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-publish-task }}
+
+      - if: (inputs.with-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
+        name: Docker Registry Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.docker-promote-repository }}
+          username: ${{ secrets.DOCKER_PROMOTE_USERNAME }}
+          password: ${{ secrets.DOCKER_PROMOTE_PASSWORD }}
+
       - name: Setup Npm with NpmJs Repository
         id: setup_npm_npmjs_pkg
         if: inputs.make-promote-task-condition || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -208,13 +208,13 @@ jobs:
 
       - name: Setup Npm with NpmJs Repository
         id: setup_npm_npmjs_pkg
-        if: inputs.make-promote-task-condition || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
         uses: komune-io/fixers-gradle/.github/actions/setup-npm-github-pkg@main
         with:
           npm-auth-token: ${{ secrets.NPM_PKG_NPMJS_TOKEN }}
           npm-registry: registry.npmjs.org
       - name: Execute Make Promote Task
-        if: inputs.make-promote-task-condition || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}


### PR DESCRIPTION
The changes allow for more flexibility in the workflow by enabling the specification of Docker registries for publishing and promoting images. Additionally, the ability to specify target platforms for Docker buildx has been added to support multi-platform builds.