### PR TITLE
chore(publish-storybook-workflow.yml): update action references to use the 'main' branch instead of specific commit hashes

### DIFF
--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -77,7 +77,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@6b6cb20e553b05f8535b10dbc3f15924c2223643
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@main
     with:
       make-file: ${{ inputs.make-file }}
       base-dir: ${{ inputs.storybook-dir }}
@@ -104,12 +104,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@6b6cb20e553b05f8535b10dbc3f15924c2223643
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@main
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}
       - name: Publish Storybook to Chromatic
-        uses: komune-io/fixers-gradle/.github/actions/chromatic@6b6cb20e553b05f8535b10dbc3f15924c2223643
+        uses: komune-io/fixers-gradle/.github/actions/chromatic@main
         with:
           storybook-dir: ${{ inputs.storybook-dir }}
           storybook-static-dir: ${{ inputs.storybook-static-dir }}
@@ -128,12 +128,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@6b6cb20e553b05f8535b10dbc3f15924c2223643
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@main
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}
       - name: Deploy Storybook to GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/github-page@6b6cb20e553b05f8535b10dbc3f15924c2223643
+        uses: komune-io/fixers-gradle/.github/actions/github-page@main
         with:
           artifact-name: ${{ inputs.storybook-dir }}
           artifact-path: ${{ inputs.storybook-dir }}/${{ inputs.storybook-static-dir }}


### PR DESCRIPTION
The commit updates the workflow file to use the 'main' branch for the actions instead of specific commit hashes. This change ensures that the latest versions of the actions are always used, improving maintainability and reducing the risk of using outdated versions.