### PR TITLE
feat(dev.yml): add make-file parameter to jobs configuration in dev.yml for specifying makefile to use

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,6 +17,7 @@ jobs:
       contents: read
       packages: write
     with:
+      make-file: 'libs.mk'
       on-tag: 'promote'
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,27 @@
 VERSION = $(shell cat VERSION)
 
-lint: lint-libs
-build: build-libs
-test: test-libs
-publish: publish-libs
-promote: promote-libs
+.PHONY: lint build test publish promote
 
-lint-libs:
-	./gradlew detekt
+## New
+lint:
+	@make -f libs.mk lint
+	@make -f docs.mk lint
 
-build-libs:
-	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
+build:
+	@make -f libs.mk build
+	@make -f docs.mk build
 
-test-libs:
-	./gradlew test
-	cd sandbox
-	./gradlew test
+test-pre:
+	@make -f libs.mk test-pre
 
-publish-libs:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
+test:
+	@make -f libs.mk test
+	@make -f docs.mk test
 
-promote-libs:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+publish:
+	@make -f libs.mk publish
+	@make -f docs.mk publish
 
-.PHONY: version
-version:
-	@echo "$(VERSION)"
+promote:
+	@make -f libs.mk promote
+	@make -f docs.mk promote

--- a/libs.mk
+++ b/libs.mk
@@ -1,0 +1,22 @@
+VERSION = $(shell cat VERSION)
+
+.PHONY: lint build test publish promote version
+
+lint:
+	./gradlew detekt
+
+build:
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
+
+test:
+	./gradlew test
+	cd sandbox && ./gradlew test
+
+publish:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
+
+promote:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+
+version:
+	@echo "$(VERSION)"


### PR DESCRIPTION
feat(Makefile): refactor Makefile to use separate makefiles for different tasks (libs.mk, docs.mk) feat(libs.mk): create new makefile for managing tasks related to libraries The changes introduce a new parameter 'make-file' in the dev.yml workflow file to specify the makefile to use for jobs. The Makefile has been refactored to use separate makefiles (libs.mk, docs.mk) for different tasks like linting, building, testing, publishing, and promoting. A new makefile, libs.mk, has been created to manage tasks related to libraries, improving modularity and organization of build tasks.