### PR TITLE
chore(setup-gradle-github-pkg): add mavenLocal repository to pluginManagement

### DIFF
--- a/.github/actions/setup-gradle-github-pkg/action.yml
+++ b/.github/actions/setup-gradle-github-pkg/action.yml
@@ -13,6 +13,7 @@ runs:
         echo "settingsEvaluated {
             pluginManagement {
                 repositories {
+                    mavenLocal()
                     gradlePluginPortal()
                     maven {
                         url = uri(\"https://maven.pkg.github.com/komune-io/fixers\")


### PR DESCRIPTION
The mavenLocal repository is added to the pluginManagement section to ensure that local Maven repositories are checked for dependencies. This change allows for easier development and testing of plugins by utilizing locally stored dependencies.