### PR TITLE
fix(dependencies): update kotlin version to 1.9.23 in FixersPluginVersions

### DIFF
--- a/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
+++ b/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
@@ -19,7 +19,7 @@ object FixersRepository {
 }
 
 object FixersPluginVersions {
-	const val kotlin = "1.9.24"
+	const val kotlin = "1.9.23"
 	const val springBoot = "3.2.5"
 	const val npmPublish = "3.4.2"
 	/**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 detekt = "1.23.6"
-kotlin = "1.9.24"
+kotlin = "1.9.23"
 dokka = "1.9.20"
 java = "11"
 sonarQube = "3.3"


### PR DESCRIPTION
The Kotlin version in the FixersPluginVersions object has been updated to 1.9.23 to align with the required version for the project dependencies.