### PR TITLE
fix(dependencies): update ksp version to 1.9.23-1.0.20 in FixersPluginVersions object

### DIFF
--- a/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
+++ b/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
@@ -25,7 +25,7 @@ object FixersPluginVersions {
 	/**
 	 * com.google.devtools.ksp
 	 */
-	const val ksp = "1.9.24-1.0.20"
+	const val ksp = "1.9.23-1.0.20"
 	/**
 	 * org.graalvm.buildtools.native.gradle.plugin
 	 */


### PR DESCRIPTION
The ksp version in the FixersPluginVersions object has been updated to 1.9.23-1.0.20 to align with the required version for compatibility or bug fixes.