### PR TITLE
feat(dependencies): update Kotlin and KSP versions to 1.9.24 in FixersPluginVersions object

### DIFF
--- a/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
+++ b/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
@@ -19,13 +19,13 @@ object FixersRepository {
 }
 
 object FixersPluginVersions {
-	const val kotlin = "1.9.23"
+	const val kotlin = "1.9.24"
 	const val springBoot = "3.2.5"
 	const val npmPublish = "3.4.2"
 	/**
 	 * com.google.devtools.ksp
 	 */
-	const val ksp = "1.9.23-1.0.20"
+	const val ksp = "1.9.24-1.0.20"
 	/**
 	 * org.graalvm.buildtools.native.gradle.plugin
 	 */

--- a/plugin/src/main/kotlin/io/komune/fixers/gradle/check/DetektConfiguration.kt
+++ b/plugin/src/main/kotlin/io/komune/fixers/gradle/check/DetektConfiguration.kt
@@ -13,6 +13,7 @@ fun Project.configureDetekt() {
     val detektReportMergeSarif: TaskProvider<ReportMergeTask> = tasks.register<ReportMergeTask>(taskName) {
         output = layout.buildDirectory.file("reports/detekt/merge.sarif")
     }
+
     allprojects {
         plugins.apply("io.gitlab.arturbosch.detekt")
         pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
@@ -44,6 +45,15 @@ fun Project.configureDetekt() {
             }
             detektReportMergeSarif.configure {
                 input.from(tasks.withType(Detekt::class.java).map { it.reports.sarif.outputLocation })
+            }
+        }
+        afterEvaluate {
+            configurations.matching { it.name == "detekt" }.all {
+                resolutionStrategy.eachDependency {
+                    if (requested.group == "org.jetbrains.kotlin") {
+                        useVersion("1.9.24")
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
feat(plugin): ensure Detekt uses Kotlin version 1.9.24 in DetektConfiguration The Kotlin and KSP versions in the FixersPluginVersions object have been updated to 1.9.24 to align with the latest versions. Additionally, the Detekt configuration now ensures that the Detekt plugin uses Kotlin version 1.9.24 for consistency and compatibility with other dependencies.