### PR TITLE
chore(make-jvm-workflow.yml): simplify conditional expressions for Docker Registry Login and Execute Make Publish Task steps

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -160,7 +160,7 @@ jobs:
           make-step: ${{ inputs.make-test-task }}
 
       - name: Docker Registry Login to Publish
-        if: (inputs.with-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/versioning/'))) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish'))))
+        if: inputs.with-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (contains(inputs.on-tag, 'publish') && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/versioning/'))) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish')))
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.docker-publish-repository }}
@@ -168,14 +168,14 @@ jobs:
           password: ${{ secrets.DOCKER_PUBLISH_PASSWORD }}
 
       - name: Execute Make Publish Task
-        if: ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/versioning/')))) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish')))
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/versioning/')))) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish'))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-publish-task }}
 
       - name: Docker Registry Login to Promote
-        if: (inputs.with-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))))
+        if: inputs.with-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')))
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.docker-promote-repository }}


### PR DESCRIPTION
The conditional expressions for the Docker Registry Login and Execute Make Publish Task steps have been simplified for better readability and maintainability. By removing unnecessary nested conditions and grouping related conditions together, the workflow file is now easier to understand and modify in the future.