### PR TITLE
fix(dependencies): downgrade jakartaPersistence version from 3.2.0 to 3.1.0

### DIFF
--- a/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
+++ b/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
@@ -44,7 +44,7 @@ object FixersVersions {
 		const val data = "3.2.6"
 		const val framework = "6.1.10"
 		const val security = "6.3.1"
-		const val jakartaPersistence = "3.2.0"
+		const val jakartaPersistence = "3.1.0"
 	}
 
 	object Json {


### PR DESCRIPTION
The jakartaPersistence version is downgraded from 3.2.0 to 3.1.0 to resolve compatibility issues or bugs that may have arisen with the newer version.