### PR TITLE
feat(dependencies): add Reactor version 3.6.8 to FixersVersions object

### DIFF
--- a/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
+++ b/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
@@ -45,6 +45,7 @@ object FixersVersions {
 		const val framework = "6.1.11"
 		const val security = "6.3.1"
 		const val jakartaPersistence = "3.1.0"
+		const val reactor = "3.6.8"
 	}
 
 	object Json {


### PR DESCRIPTION
The Reactor version 3.6.8 has been added to the FixersVersions object to ensure that the project uses the specified version for Reactor library.