### PR TITLE
fix(gradle): update Gradle distribution URL to version 8.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue May 12 13:09:39 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The Gradle distribution URL has been updated to point to version 8.9 instead of 8.6, ensuring that the project uses the latest available version of Gradle for building and managing dependencies.