### PR TITLE
feat(make-jvm-workflow.yml): add force-publish flag to allow for forced execution of the publish task

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -68,6 +68,12 @@ on:
         type: "string"
         default: "ghcr.io"
 
+      force-publish:
+        description: "Flag to force execute publish task."
+        required: false
+        type: "string"
+        default: "false"
+
       docker-promote-repository:
         description: "The Docker registry to which images should be promoted. Defaults to Docker Hub (docker.io)."
         required: false
@@ -168,7 +174,7 @@ jobs:
           password: ${{ secrets.DOCKER_PUBLISH_PASSWORD }}
 
       - name: Execute Make Publish Task
-        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && startsWith(github.ref, 'refs/tags/'))) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'publish') || startsWith(github.ref, 'refs/heads/versioning/')))
+        if: (force-publish == 'true' || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && startsWith(github.ref, 'refs/tags/'))) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'publish') || startsWith(github.ref, 'refs/heads/versioning/'))))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -174,7 +174,7 @@ jobs:
           password: ${{ secrets.DOCKER_PUBLISH_PASSWORD }}
 
       - name: Execute Make Publish Task
-        if: (github.force-publish == 'true' || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && startsWith(github.ref, 'refs/tags/'))) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'publish') || startsWith(github.ref, 'refs/heads/versioning/'))))
+        if: (inputs.force-publish == 'true' || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && startsWith(github.ref, 'refs/tags/'))) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'publish') || startsWith(github.ref, 'refs/heads/versioning/'))))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -166,7 +166,7 @@ jobs:
           make-step: ${{ inputs.make-test-task }}
 
       - name: Docker Registry Login to Publish
-        if: (inputs.with-docker-registry-login == 'true' &&((github.ref == 'refs/heads/main' ||startsWith(github.ref, 'refs/heads/release/') ||startsWith(github.ref, 'refs/heads/versioning/') ||(contains(inputs.on-tag, 'publish') && startsWith(github.ref, 'refs/tags/'))) ||(github.event_name == 'pull_request' &&(contains(github.event.pull_request.labels.*.name, 'publish') || startsWith(github.ref, 'refs/heads/versioning/')))))
+        if: (inputs.force-publish == 'true' || (inputs.with-docker-registry-login == 'true' &&((github.ref == 'refs/heads/main' ||startsWith(github.ref, 'refs/heads/release/') ||startsWith(github.ref, 'refs/heads/versioning/') ||(contains(inputs.on-tag, 'publish') && startsWith(github.ref, 'refs/tags/'))) ||(github.event_name == 'pull_request' &&(contains(github.event.pull_request.labels.*.name, 'publish') || startsWith(github.ref, 'refs/heads/versioning/'))))))
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.docker-publish-repository }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -174,7 +174,7 @@ jobs:
           password: ${{ secrets.DOCKER_PUBLISH_PASSWORD }}
 
       - name: Execute Make Publish Task
-        if: (force-publish == 'true' || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && startsWith(github.ref, 'refs/tags/'))) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'publish') || startsWith(github.ref, 'refs/heads/versioning/'))))
+        if: (github.force-publish == 'true' || (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || (contains(inputs.on-tag, 'publish') && startsWith(github.ref, 'refs/tags/'))) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'publish') || startsWith(github.ref, 'refs/heads/versioning/'))))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}


### PR DESCRIPTION
The force-publish flag has been added to the workflow configuration file. This flag allows for the forced execution of the publish task regardless of the conditions specified in the workflow. This provides flexibility in cases where the publish task needs to be executed forcefully.