### PR TITLE
ci(workflow): add SONAR_TOKEN secret to GitHub Actions environment variables

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -137,6 +137,7 @@ jobs:
       PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
       PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
       PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Include SONAR_TOKEN to enable SonarQube analysis in the CI pipeline. This addition allows the workflow to authenticate with SonarQube, facilitating code quality and security checks during the build process.