### PR TITLE
Add run-not-on Input for Conditional Workflow Job Execution

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -134,7 +134,7 @@ on:
 
 jobs:
   run-dev-tasks:
-    if: ${{ github.event_name == 'push' && !contains(fromJson(inputs.excluded-branches), github.ref) }}
+    if: ${{ github.event_name == 'push' && !(startsWith(github.ref, 'refs/heads/versioning/') || startsWith(github.ref, 'refs/heads/test/')) }}
     runs-on: ubuntu-latest
     env:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -134,7 +134,6 @@ on:
 
 jobs:
   run-dev-tasks:
-    if: ${{ github.event_name == 'push' && !startsWith(github.ref, format('refs/heads/{0}', inputs.excluded-branch)) }}
     runs-on: ubuntu-latest
     env:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
@@ -145,6 +144,12 @@ jobs:
       PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
+      - name: Debug Print inputs and ref
+        run: |
+          echo "Excluded Branch Prefix: ${{ inputs.excluded-branch }}"
+          echo "Excluded Branch Prefix format: ${{ format('refs/heads/{0}', inputs.excluded-branch) }}"
+          echo "Current GitHub Ref: ${{ github.ref }}"
+
       - name: Checkout Repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -21,11 +21,11 @@ on:
         default: 'false'
         type: "string"
 
-      excluded-branches:
+      excluded-branch:
         description: "A JSON-formatted list of branch name prefixes or event names on which the job should be excluded from running. For example, use ['versioning/', 'test/'] to skip running the job on any branch that starts with 'versioning/' or 'test/'."
         required: false
         type: "string"
-        default: "['versioning/', 'test/']"
+        default: "versioning/"
 
       make-file:
         description: "The Makefile to execute."
@@ -134,7 +134,7 @@ on:
 
 jobs:
   run-dev-tasks:
-    if: ${{ github.event_name == 'push' && !(startsWith(github.ref, 'refs/heads/versioning/') || startsWith(github.ref, 'refs/heads/test/')) }}
+    if: ${{ github.event_name == 'push' && !startsWith(github.ref, format('refs/heads/{0}', inputs.excluded-branch)) }}
     runs-on: ubuntu-latest
     env:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -21,11 +21,11 @@ on:
         default: 'false'
         type: "string"
 
-      excluded-branches:
+      excluded-branch:
         description: "A JSON-formatted list of branch name prefixes or event names on which the job should be excluded from running. For example, use ['versioning/', 'test/'] to skip running the job on any branch that starts with 'versioning/' or 'test/'."
         required: false
         type: "string"
-        default: "['versioning/', 'test/']"
+        default: "versioning/"
 
       make-file:
         description: "The Makefile to execute."
@@ -134,7 +134,7 @@ on:
 
 jobs:
   run-dev-tasks:
-    if: ${{ github.event_name == 'push' && !contains(fromJson(inputs.excluded-branches), github.ref) }}
+    if: ${{ github.event_name == 'push' && !(startsWith(github.ref, format('refs/heads/{0}', inputs.excluded-branch)) || startsWith(github.ref, 'refs/heads/test/')) }}
     runs-on: ubuntu-latest
     env:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -21,11 +21,11 @@ on:
         default: 'false'
         type: "string"
 
-      excluded-branch:
+      excluded-branches:
         description: "A JSON-formatted list of branch name prefixes or event names on which the job should be excluded from running. For example, use ['versioning/', 'test/'] to skip running the job on any branch that starts with 'versioning/' or 'test/'."
         required: false
         type: "string"
-        default: "versioning/"
+        default: "['versioning/', 'test/']"
 
       make-file:
         description: "The Makefile to execute."
@@ -134,7 +134,7 @@ on:
 
 jobs:
   run-dev-tasks:
-    if: ${{ github.event_name == 'push' && !(startsWith(github.ref, format('refs/heads/{0}', inputs.excluded-branch)) || startsWith(github.ref, 'refs/heads/test/')) }}
+    if: ${{ github.event_name == 'push' && !contains(fromJson(inputs.excluded-branches), github.ref) }}
     runs-on: ubuntu-latest
     env:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -21,6 +21,12 @@ on:
         default: 'false'
         type: "string"
 
+      excluded-branches:
+        description: "A JSON-formatted list of branch name prefixes or event names on which the job should be excluded from running. For example, use ['versioning/', 'test/'] to skip running the job on any branch that starts with 'versioning/' or 'test/'."
+        required: false
+        type: "string"
+        default: "['versioning/', 'test/']"
+
       make-file:
         description: "The Makefile to execute."
         required: false
@@ -128,7 +134,7 @@ on:
 
 jobs:
   run-dev-tasks:
-    if: (!startsWith(github.event.pull_request.head.ref, 'versionning/') || github.event_name != 'pull_request')
+    if: ${{ github.event_name == 'push' && !contains(fromJson(inputs.excluded-branches), github.ref) }}
     runs-on: ubuntu-latest
     env:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}


### PR DESCRIPTION
Introduced a run-not-on input to control job execution based on branch prefixes or event names.
Provides flexibility to exclude specific branches or events, with a default value set to "versioning/".