### PR TITLE
Update Spring Boot and Related Dependencies to Latest Versions

### DIFF
--- a/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
+++ b/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
@@ -20,7 +20,7 @@ object FixersRepository {
 
 object FixersPluginVersions {
 	const val kotlin = "1.9.25"
-	const val springBoot = "3.3.2"
+	const val springBoot = "3.3.4"
 	const val npmPublish = "3.4.2"
 	/**
 	 * com.google.devtools.ksp
@@ -41,9 +41,9 @@ object FixersVersions {
 
 	object Spring {
 		const val boot = FixersPluginVersions.springBoot
-		const val data = "3.3.2"
-		const val framework = "6.1.11"
-		const val security = "6.3.1"
+		const val data = "3.3.4"
+		const val framework = "6.1.13"
+		const val security = "6.3.3"
 		const val jakartaPersistence = "3.1.0"
 		const val reactor = "3.6.8"
 	}


### PR DESCRIPTION
This merge request updates the following dependencies:
- Spring Boot to version 3.3.4
- Spring Data to version 3.3.4
- Spring Framework to version 6.1.13
- Spring Security to version 6.3.3

These updates improve compatibility, stability, and security by incorporating the latest features and patches.





