### PR TITLE
Fix code scanning alert no. 35: Expression injection in Actions

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -52,15 +52,18 @@ runs:
   using: "composite"
   steps:
     - name: "Set Version Tag for Branch"
+      env:
+        GITHUB_HEAD_REF: ${{ github.head_ref }}
+        GITHUB_REF: ${{ github.ref }}
       run: |
         VERSION=$(cat VERSION)
         echo "Original VERSION: $VERSION"
 
           # Initialize BRANCH_NAME_REF based on the event type
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BRANCH_NAME_REF="refs/heads/${{ github.head_ref }}"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            BRANCH_NAME_REF="refs/heads/$GITHUB_HEAD_REF"
           else
-            BRANCH_NAME_REF="${{ github.ref }}"
+            BRANCH_NAME_REF="$GITHUB_REF"
           fi
           echo "Branch Name: $BRANCH_NAME_REF"
 


### PR DESCRIPTION
Fixes [https://github.com/komune-io/fixers-gradle/security/code-scanning/35](https://github.com/komune-io/fixers-gradle/security/code-scanning/35)

To fix the problem, we need to avoid directly interpolating user-controlled input into shell commands. Instead, we should set these values to intermediate environment variables and then use the environment variables in the shell script. This approach ensures that the shell interpreter handles the variables safely.

1. Set the values of `${{ github.head_ref }}` and `${{ github.ref }}` to environment variables.
2. Use the environment variables in the shell script instead of direct interpolation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
