### PR TITLE
Update dependencies and downgrade Jackson to 2.17.2 due to compatibility issues

### DIFF
--- a/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
+++ b/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
@@ -49,7 +49,7 @@ object FixersVersions {
 	}
 
 	object Json {
-		const val jackson = "2.18.0"
+		const val jackson = "2.17.2"
 		const val jacksonKotlin = jackson
 	}
 


### PR DESCRIPTION
Updated various dependencies to their latest versions for stability and new features. Downgraded Jackson library from 2.18.0 to 2.17.2 to resolve compatibility issues found in version 2.18.0.
