### PR TITLE
ci(workflow): add Firefox setup step for Kotlin tests in GitHub Actions

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -148,6 +148,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Add Firefox to Run Kotlin test
+        uses: browser-actions/setup-firefox@v1
+
       - name: Initialize Java and Gradle Environment
         uses: komune-io/fixers-gradle/.github/actions/jvm@main
         with:


### PR DESCRIPTION
Include a step to set up Firefox in the GitHub Actions workflow to ensure that Kotlin tests requiring a browser environment can run successfully. This change is necessary to support tests that depend on Firefox, ensuring they execute correctly in the CI environment.