### PR TITLE
chore(dependencies): update Spring Boot version from 3.3.4 to 3.3.6

### DIFF
--- a/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
+++ b/dependencies/src/main/kotlin/io/komune/gradle/dependencies/Dependencies.kt
@@ -20,7 +20,7 @@ object FixersRepository {
 
 object FixersPluginVersions {
 	const val kotlin = "1.9.25"
-	const val springBoot = "3.3.4"
+	const val springBoot = "3.3.6"
 	const val npmPublish = "3.4.2"
 	/**
 	 * com.google.devtools.ksp


### PR DESCRIPTION
Update the Spring Boot version to incorporate the latest bug fixes, security patches, and performance improvements. Keeping dependencies up-to-date ensures the project benefits from the latest enhancements and maintains compatibility with other libraries.