### PR TITLE
refactor: Consolidate publishing system and migrate to JReleaser with improved configuration management

### DIFF
--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/DetektConfiguration.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/DetektConfiguration.kt
@@ -26,8 +26,8 @@ fun Project.configureDetekt() {
         plugins.apply("io.gitlab.arturbosch.detekt")
 
         pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
-            val detectXmlPath = "${layout.buildDirectory.asFile.get()}/reports/detekt/detekt.xml"
-            val detectSarifPath = "${layout.buildDirectory.asFile.get()}/reports/detekt/detekt.sarif"
+            val detectXmlPath = layout.buildDirectory.file("reports/detekt/detekt.xml")
+            val detectSarifPath = layout.buildDirectory.file("reports/detekt/detekt.sarif")
             extensions.configure(DetektExtension::class.java) {
                 val sourceDirs = file("src")
                     .listFiles()

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/config/TsGenTask.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/config/TsGenTask.kt
@@ -36,7 +36,9 @@ fun Project.configureKt2Ts(mainConfig: ConfigExtension?) {
 
                 val cleaning = config.buildCleaningRegex()
 
-                cleanSubProjects(cleaning)
+                doFirst {
+                    cleanSubProjects(cleaning)
+                }
                 eachFile {
                     file.cleanFile(cleaning)
                 }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/npm/NpmPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/npm/NpmPlugin.kt
@@ -30,7 +30,7 @@ class NpmPlugin : Plugin<Project> {
 			onlyIf { npm.clean.get() }
 		}
 		afterEvaluate {
-			logger.error("afterEvaluate - Apply NpmPlugin to ${this.name}")
+			logger.info("afterEvaluate - Apply NpmPlugin to ${this.name}")
 			tasks.withType(NpmPublishTask::class.java).forEach {
 				it.apply {
 					dependsOn(tasks.withType(NpmTsGenTask::class.java))

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetup.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetup.kt
@@ -12,6 +12,7 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.the
 
 object PublishJvmSetup {
 
@@ -73,7 +74,7 @@ object PublishJvmSetup {
 
 			tasks.register("sourcesJar", Jar::class.java) {
 				archiveClassifier.set("sources")
-				(properties["sourceSets"] as? SourceSetContainer)?.let { sourceSets ->
+				project.the<SourceSetContainer>().let { sourceSets ->
 					from(sourceSets["main"].allSource)
 				}
 			}


### PR DESCRIPTION
This MR introduces a comprehensive overhaul of the publishing system, consolidating multiple publishing files into a single PublishingPlugin with JReleaser integration for Maven Central deployment. The changes migrate from legacy publishing approaches to a more streamlined deployment strategy using STAGE instead of PUBLISH types.

Additionally, the configuration system is enhanced by migrating to Gradle's Property API for improved type safety, adding centralized version management from VERSION files, and implementing automated build tasks for better configuration source management.