### PR TITLE
chore(JReleaserDeployer.kt): remove GitHub username and token from deployment configuration to enhance security

### DIFF
--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/JReleaserDeployer.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/JReleaserDeployer.kt
@@ -114,8 +114,6 @@ object JReleaserDeployer {
                 active.set(project.provider {
                     if (fixersConfig.publish.isStage.get()) Active.ALWAYS else Active.NEVER
                 })
-                username.set(fixersConfig.publish.pkgGithubUsername)
-                password.set(fixersConfig.publish.pkgGithubToken)
                 url.set(fixersConfig.publish.githubPackagesUrl)
                 applyMavenCentralRules.set(true)
                 snapshotSupported.set(true)


### PR DESCRIPTION
The GitHub username and token are removed from the deployment configuration to prevent sensitive information from being exposed in the codebase. This change enhances security by ensuring that credentials are not hardcoded and encourages the use of more secure methods for managing sensitive data.