### PR TITLE
chore(dev.yml): mark Docker publish credentials as deprecated in GitHub Actions workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,6 +41,10 @@ jobs:
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      # DEPRECATED
+      DOCKER_PUBLISH_USERNAME: ${{ github.actor }}
+      # DEPRECATED
+      DOCKER_PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}


### PR DESCRIPTION
The Docker publish username and password are marked as deprecated to indicate that they should no longer be used. This change helps to clarify the workflow configuration and encourages the use of updated authentication methods.