### PR TITLE
chore(workflow): add type definition for Docker login flag in GitHub Actions workflow

### DIFF
--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -30,6 +30,7 @@ on:
         description: 'Flag to enable Docker login to the promote Docker registry.'
         required: false
         default: 'true'
+        type: "string"
 
       excluded-versioning-branch:
         description: "A single branch name prefix where the job should be excluded from running. For example, use 'versioning/' to skip running the job on any branch that starts with 'versioning/'."


### PR DESCRIPTION
The type for the Docker login flag is now explicitly defined as a string. This improves clarity and ensures that users understand the expected input type for this parameter, enhancing the overall usability of the workflow configuration.