### PR TITLE
feat(action): enhance Node.js environment setup with automatic package manager detection and caching for npm, yarn, and pnpm

### DIFF
--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -4,10 +4,16 @@ inputs:
   storybook-dir:
     description: "Storybook base directory"
     required: false
+    default: "."
 
   storybook-static-dir:
     description: "Path to the storybook-static"
     required: true
+
+  storybook-static-dir-separator:
+    description: "Path separator between storybook-dir and storybook-static-dir"
+    required: false
+    default: "/"
 
   project-token:
     description: "Path to the artifact to upload, leave empty if no artifact is needed"
@@ -23,7 +29,7 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: storybook-static
-        path: ${{ inputs.storybook-dir }}/${{ inputs.storybook-static-dir }}
+        path: ${{ inputs.storybook-dir }}${{ inputs.storybook-static-dir-separator }}${{ inputs.storybook-static-dir }}
     - name: Publish to Chromatic
       id: chromatic
       uses: chromaui/action@latest

--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -4,7 +4,6 @@ inputs:
   storybook-dir:
     description: "Storybook base directory"
     required: false
-    default: "."
 
   storybook-static-dir:
     description: "Path to the storybook-static"

--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -4,6 +4,7 @@ inputs:
   storybook-dir:
     description: "Storybook base directory"
     required: false
+    default: "."
 
   storybook-static-dir:
     description: "Path to the storybook-static"

--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -37,6 +37,12 @@ runs:
           echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
         fi
 
+    - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
+      name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: latest
+
     - if: inputs.base-dir != ''
       name: Setup Node with base-dir ${{ inputs.node-version }}
       uses: actions/setup-node@v4
@@ -51,12 +57,6 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ steps.detect-package-manager.outputs.package-manager }}
-
-    - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
-      name: Install pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: latest
 
     - if: steps.detect-package-manager.outputs.package-manager == 'yarn'
       uses: actions/cache@v4

--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -1,5 +1,5 @@
 name: "Node.js Environment Setup and Dependency Caching"
-description: "This workflow sets up a Node.js environment, caches dependencies, and configures authentication for private NPM packages."
+description: "This workflow sets up a Node.js environment with automatic package manager detection (yarn/pnpm/npm), caches dependencies, and configures authentication for private NPM packages."
 inputs:
   base-dir:
     description: "Base directory of the Node.js project, if applicable."
@@ -13,22 +13,47 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Detect package manager
+      id: detect-pm
+      shell: bash
+      run: |
+        if [[ "${{ inputs.base-dir }}" != "" ]]; then
+          base_dir="${{ inputs.base-dir }}"
+        else
+          base_dir="."
+        fi
+        
+        if [ -f "$base_dir/pnpm-lock.yaml" ]; then
+          echo "pm=pnpm" >> $GITHUB_OUTPUT
+          echo "lockfile=pnpm-lock.yaml" >> $GITHUB_OUTPUT
+        elif [ -f "$base_dir/yarn.lock" ]; then
+          echo "pm=yarn" >> $GITHUB_OUTPUT
+          echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
+        elif [ -f "$base_dir/package-lock.json" ]; then
+          echo "pm=npm" >> $GITHUB_OUTPUT
+          echo "lockfile=package-lock.json" >> $GITHUB_OUTPUT
+        else
+          echo "pm=yarn" >> $GITHUB_OUTPUT
+          echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
+        fi
+
     - if: inputs.base-dir != ''
       name: Setup Node with base-dir ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: "yarn"
-        cache-dependency-path: ${{ github.workspace }}/${{ inputs.base-dir }}/yarn.lock
+        cache: ${{ steps.detect-pm.outputs.pm }}
+        cache-dependency-path: ${{ github.workspace }}/${{ inputs.base-dir }}/${{ steps.detect-pm.outputs.lockfile }}
 
     - if: inputs.base-dir == ''
       name: Setup Node without base-dir ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: "yarn"
+        cache: ${{ steps.detect-pm.outputs.pm }}
 
-    - uses: actions/cache@v4
+    - if: steps.detect-pm.outputs.pm == 'yarn'
+      uses: actions/cache@v4
       id: yarn-modules-cache
       with:
         path: "**/node_modules"
@@ -36,10 +61,49 @@ runs:
         restore-keys: |
           ${{ runner.os }}-yarn-modules-
 
-    - uses: actions/cache@v4
+    - if: steps.detect-pm.outputs.pm == 'pnpm'
+      uses: actions/cache@v4
+      id: pnpm-modules-cache
+      with:
+        path: |
+          ~/.pnpm-store
+          **/node_modules
+        key: ${{ runner.os }}-pnpm-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-modules-
+
+    - if: steps.detect-pm.outputs.pm == 'npm'
+      uses: actions/cache@v4
+      id: npm-modules-cache
+      with:
+        path: "**/node_modules"
+        key: ${{ runner.os }}-npm-modules-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-modules-
+
+    - if: steps.detect-pm.outputs.pm == 'yarn'
+      uses: actions/cache@v4
       id: yarn-dist-cache
       with:
         path: "**/dist"
         key: ${{ runner.os }}-yarn-dist-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-dist-
+
+    - if: steps.detect-pm.outputs.pm == 'pnpm'
+      uses: actions/cache@v4
+      id: pnpm-dist-cache
+      with:
+        path: "**/dist"
+        key: ${{ runner.os }}-pnpm-dist-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-dist-
+
+    - if: steps.detect-pm.outputs.pm == 'npm'
+      uses: actions/cache@v4
+      id: npm-dist-cache
+      with:
+        path: "**/dist"
+        key: ${{ runner.os }}-npm-dist-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-dist-

--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Detect package manager
-      id: detect-pm
+      id: detect-package-manager
       shell: bash
       run: |
         if [[ "${{ inputs.base-dir }}" != "" ]]; then
@@ -24,16 +24,16 @@ runs:
         fi
         
         if [ -f "$base_dir/pnpm-lock.yaml" ]; then
-          echo "pm=pnpm" >> $GITHUB_OUTPUT
+          echo "package-manager=pnpm" >> $GITHUB_OUTPUT
           echo "lockfile=pnpm-lock.yaml" >> $GITHUB_OUTPUT
         elif [ -f "$base_dir/yarn.lock" ]; then
-          echo "pm=yarn" >> $GITHUB_OUTPUT
+          echo "package-manager=yarn" >> $GITHUB_OUTPUT
           echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
         elif [ -f "$base_dir/package-lock.json" ]; then
-          echo "pm=npm" >> $GITHUB_OUTPUT
+          echo "package-manager=npm" >> $GITHUB_OUTPUT
           echo "lockfile=package-lock.json" >> $GITHUB_OUTPUT
         else
-          echo "pm=yarn" >> $GITHUB_OUTPUT
+          echo "package-manager=yarn" >> $GITHUB_OUTPUT
           echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
         fi
 
@@ -42,28 +42,28 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: ${{ steps.detect-pm.outputs.pm }}
-        cache-dependency-path: ${{ github.workspace }}/${{ inputs.base-dir }}/${{ steps.detect-pm.outputs.lockfile }}
+        cache: ${{ steps.detect-package-manager.outputs.package-manager }}
+        cache-dependency-path: ${{ github.workspace }}/${{ inputs.base-dir }}/${{ steps.detect-package-manager.outputs.lockfile }}
 
     - if: inputs.base-dir == ''
       name: Setup Node without base-dir ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: ${{ steps.detect-pm.outputs.pm }}
+        cache: ${{ steps.detect-package-manager.outputs.package-manager }}
 
-    - if: steps.detect-pm.outputs.pm == 'yarn'
+    - if: steps.detect-package-manager.outputs.package-manager == 'yarn'
       uses: actions/cache@v4
-      id: yarn-modules-cache
+      id: package-manager-modules-cache
       with:
         path: "**/node_modules"
         key: ${{ runner.os }}-yarn-modules-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-modules-
 
-    - if: steps.detect-pm.outputs.pm == 'pnpm'
+    - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
       uses: actions/cache@v4
-      id: pnpm-modules-cache
+      id: package-manager-modules-cache
       with:
         path: |
           ~/.pnpm-store
@@ -72,36 +72,36 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-modules-
 
-    - if: steps.detect-pm.outputs.pm == 'npm'
+    - if: steps.detect-package-manager.outputs.package-manager == 'npm'
       uses: actions/cache@v4
-      id: npm-modules-cache
+      id: package-manager-modules-cache
       with:
         path: "**/node_modules"
         key: ${{ runner.os }}-npm-modules-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-npm-modules-
 
-    - if: steps.detect-pm.outputs.pm == 'yarn'
+    - if: steps.detect-package-manager.outputs.package-manager == 'yarn'
       uses: actions/cache@v4
-      id: yarn-dist-cache
+      id: package-manager-dist-cache
       with:
         path: "**/dist"
         key: ${{ runner.os }}-yarn-dist-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-dist-
 
-    - if: steps.detect-pm.outputs.pm == 'pnpm'
+    - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
       uses: actions/cache@v4
-      id: pnpm-dist-cache
+      id: package-manager-dist-cache
       with:
         path: "**/dist"
         key: ${{ runner.os }}-pnpm-dist-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-dist-
 
-    - if: steps.detect-pm.outputs.pm == 'npm'
+    - if: steps.detect-package-manager.outputs.package-manager == 'npm'
       uses: actions/cache@v4
-      id: npm-dist-cache
+      id: package-manager-dist-cache
       with:
         path: "**/dist"
         key: ${{ runner.os }}-npm-dist-${{ hashFiles('**/package-lock.json') }}

--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -58,58 +58,10 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: ${{ steps.detect-package-manager.outputs.package-manager }}
 
-    - if: steps.detect-package-manager.outputs.package-manager == 'yarn'
-      uses: actions/cache@v4
-      id: yarn-modules-cache
-      with:
-        path: "**/node_modules"
-        key: ${{ runner.os }}-yarn-modules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-modules-
-
-    - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
-      uses: actions/cache@v4
-      id: pnpm-modules-cache
-      with:
-        path: |
-          ~/.pnpm-store
-          **/node_modules
-        key: ${{ runner.os }}-pnpm-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-modules-
-
-    - if: steps.detect-package-manager.outputs.package-manager == 'npm'
-      uses: actions/cache@v4
-      id: npm-modules-cache
-      with:
-        path: "**/node_modules"
-        key: ${{ runner.os }}-npm-modules-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-npm-modules-
-
-    - if: steps.detect-package-manager.outputs.package-manager == 'yarn'
-      uses: actions/cache@v4
-      id: yarn-dist-cache
+    - uses: actions/cache@v4
+      id: dist-cache
       with:
         path: "**/dist"
-        key: ${{ runner.os }}-yarn-dist-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-dist-${{ hashFiles(format('**/{0}', steps.detect-package-manager.outputs.lockfile)) }}
         restore-keys: |
-          ${{ runner.os }}-yarn-dist-
-
-    - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
-      uses: actions/cache@v4
-      id: pnpm-dist-cache
-      with:
-        path: "**/dist"
-        key: ${{ runner.os }}-pnpm-dist-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-dist-
-
-    - if: steps.detect-package-manager.outputs.package-manager == 'npm'
-      uses: actions/cache@v4
-      id: npm-dist-cache
-      with:
-        path: "**/dist"
-        key: ${{ runner.os }}-npm-dist-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-npm-dist-
+          ${{ runner.os }}-dist-

--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -52,6 +52,12 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: ${{ steps.detect-package-manager.outputs.package-manager }}
 
+    - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
+      name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: latest
+
     - if: steps.detect-package-manager.outputs.package-manager == 'yarn'
       uses: actions/cache@v4
       id: yarn-modules-cache

--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - if: steps.detect-package-manager.outputs.package-manager == 'yarn'
       uses: actions/cache@v4
-      id: package-manager-modules-cache
+      id: yarn-modules-cache
       with:
         path: "**/node_modules"
         key: ${{ runner.os }}-yarn-modules-${{ hashFiles('**/yarn.lock') }}
@@ -63,7 +63,7 @@ runs:
 
     - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
       uses: actions/cache@v4
-      id: package-manager-modules-cache
+      id: pnpm-modules-cache
       with:
         path: |
           ~/.pnpm-store
@@ -74,7 +74,7 @@ runs:
 
     - if: steps.detect-package-manager.outputs.package-manager == 'npm'
       uses: actions/cache@v4
-      id: package-manager-modules-cache
+      id: npm-modules-cache
       with:
         path: "**/node_modules"
         key: ${{ runner.os }}-npm-modules-${{ hashFiles('**/package-lock.json') }}
@@ -83,7 +83,7 @@ runs:
 
     - if: steps.detect-package-manager.outputs.package-manager == 'yarn'
       uses: actions/cache@v4
-      id: package-manager-dist-cache
+      id: yarn-dist-cache
       with:
         path: "**/dist"
         key: ${{ runner.os }}-yarn-dist-${{ hashFiles('**/yarn.lock') }}
@@ -92,7 +92,7 @@ runs:
 
     - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
       uses: actions/cache@v4
-      id: package-manager-dist-cache
+      id: pnpm-dist-cache
       with:
         path: "**/dist"
         key: ${{ runner.os }}-pnpm-dist-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -101,7 +101,7 @@ runs:
 
     - if: steps.detect-package-manager.outputs.package-manager == 'npm'
       uses: actions/cache@v4
-      id: package-manager-dist-cache
+      id: npm-dist-cache
       with:
         path: "**/dist"
         key: ${{ runner.os }}-npm-dist-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -164,7 +164,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Node.js Environment
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@ea5bf711da9bdb237d239a4c60916f2741bc0fb8
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@beb8afdc4eb334c90cbada0a4a2571f17d02515d
         with:
           base-dir: ${{ inputs.base-dir }}
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -164,7 +164,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Node.js Environment
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@7cfd6da9011be3c241632d32b56e4ea82bf201a4
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@ea5bf711da9bdb237d239a4c60916f2741bc0fb8
         with:
           base-dir: ${{ inputs.base-dir }}
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -164,7 +164,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Node.js Environment
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@main
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@a8793d91302765c5dafd755d82bb0bcf9ad2b142
         with:
           base-dir: ${{ inputs.base-dir }}
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -164,7 +164,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Node.js Environment
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@5805c22d818c20b9b0077096a021c1161c1cf7f8
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@main
         with:
           base-dir: ${{ inputs.base-dir }}
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -164,7 +164,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Node.js Environment
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@beb8afdc4eb334c90cbada0a4a2571f17d02515d
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@5805c22d818c20b9b0077096a021c1161c1cf7f8
         with:
           base-dir: ${{ inputs.base-dir }}
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -164,7 +164,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Node.js Environment
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@a8793d91302765c5dafd755d82bb0bcf9ad2b142
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@7cfd6da9011be3c241632d32b56e4ea82bf201a4
         with:
           base-dir: ${{ inputs.base-dir }}
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -24,12 +24,13 @@ on:
         description: "The base directory of the Node.js project."
         required: false
         type: "string"
+        default: ""
 
       storybook-dir:
         description: "The base directory where the Storybook configuration resides."
         required: false
         type: "string"
-        default: "storybook"
+        default: "."
 
       # DEPRECATED
       docker-publish-repository:
@@ -138,6 +139,7 @@ jobs:
         with:
           storybook-dir: ${{ inputs.storybook-dir }}
           storybook-static-dir: ${{ inputs.storybook-static-dir }}
+          storybook-static-dir-separator: ${{ inputs.storybook-static-dir-separator }}
           project-token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
   publish-github-page:
@@ -160,5 +162,5 @@ jobs:
       - name: Deploy Storybook to GitHub Pages
         uses: komune-io/fixers-gradle/.github/actions/github-page@main
         with:
-          artifact-name: ${{ inputs.storybook-dir }}
-          artifact-path: ${{ inputs.storybook-dir }}/${{ inputs.storybook-static-dir }}
+          artifact-name: ${{ inputs.storybook-static-dir }}
+          artifact-path: ${{ inputs.storybook-dir }}${{ inputs.storybook-static-dir-separator }}${{ inputs.storybook-static-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -97,7 +97,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@541f8c4e459f3e208cd531c1e97917ad19abde26
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@f563b0b6185c44c5ecdae390047f79c585b613ba
     with:
       make-file: ${{ inputs.make-file }}
       base-dir: ${{ inputs.base-dir }}
@@ -130,12 +130,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@541f8c4e459f3e208cd531c1e97917ad19abde26
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@f563b0b6185c44c5ecdae390047f79c585b613ba
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.base-dir }}
       - name: Publish Storybook to Chromatic
-        uses: komune-io/fixers-gradle/.github/actions/chromatic@541f8c4e459f3e208cd531c1e97917ad19abde26
+        uses: komune-io/fixers-gradle/.github/actions/chromatic@f563b0b6185c44c5ecdae390047f79c585b613ba
         with:
           storybook-dir: ${{ inputs.storybook-dir }}
           storybook-static-dir: ${{ inputs.storybook-static-dir }}
@@ -155,7 +155,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@541f8c4e459f3e208cd531c1e97917ad19abde26
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@f563b0b6185c44c5ecdae390047f79c585b613ba
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.base-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -132,7 +132,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/nodejs@541f8c4e459f3e208cd531c1e97917ad19abde26
         with:
           node-version: ${{ inputs.node-version }}
-          base-dir: ${{ inputs.storybook-dir }}
+          base-dir: ${{ inputs.base-dir }}
       - name: Publish Storybook to Chromatic
         uses: komune-io/fixers-gradle/.github/actions/chromatic@541f8c4e459f3e208cd531c1e97917ad19abde26
         with:
@@ -156,7 +156,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/nodejs@541f8c4e459f3e208cd531c1e97917ad19abde26
         with:
           node-version: ${{ inputs.node-version }}
-          base-dir: ${{ inputs.storybook-dir }}
+          base-dir: ${{ inputs.base-dir }}
       - name: Deploy Storybook to GitHub Pages
         uses: komune-io/fixers-gradle/.github/actions/github-page@main
         with:

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -90,7 +90,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@bc5c7e881a6b50ca929cb8a100cea3bed77fbf6c
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@5805c22d818c20b9b0077096a021c1161c1cf7f8
     with:
       make-file: ${{ inputs.make-file }}
       base-dir: ${{ inputs.storybook-dir }}
@@ -123,7 +123,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@beb8afdc4eb334c90cbada0a4a2571f17d02515d
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@5805c22d818c20b9b0077096a021c1161c1cf7f8
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -90,7 +90,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@beb8afdc4eb334c90cbada0a4a2571f17d02515d
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@bc5c7e881a6b50ca929cb8a100cea3bed77fbf6c
     with:
       make-file: ${{ inputs.make-file }}
       base-dir: ${{ inputs.storybook-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@a8793d91302765c5dafd755d82bb0bcf9ad2b142
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@7cfd6da9011be3c241632d32b56e4ea82bf201a4
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}
@@ -147,7 +147,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@a8793d91302765c5dafd755d82bb0bcf9ad2b142
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@7cfd6da9011be3c241632d32b56e4ea82bf201a4
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -97,7 +97,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@f563b0b6185c44c5ecdae390047f79c585b613ba
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@main
     with:
       make-file: ${{ inputs.make-file }}
       base-dir: ${{ inputs.base-dir }}
@@ -130,12 +130,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@f563b0b6185c44c5ecdae390047f79c585b613ba
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@main
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.base-dir }}
       - name: Publish Storybook to Chromatic
-        uses: komune-io/fixers-gradle/.github/actions/chromatic@f563b0b6185c44c5ecdae390047f79c585b613ba
+        uses: komune-io/fixers-gradle/.github/actions/chromatic@main
         with:
           storybook-dir: ${{ inputs.storybook-dir }}
           storybook-static-dir: ${{ inputs.storybook-static-dir }}
@@ -155,7 +155,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@f563b0b6185c44c5ecdae390047f79c585b613ba
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@main
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.base-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -90,7 +90,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@beb8afdc4eb334c90cbada0a4a2571f17d02515d
     with:
       make-file: ${{ inputs.make-file }}
       base-dir: ${{ inputs.storybook-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -7,6 +7,7 @@ on:
         description: "The Node.js version to use for the workflow."
         required: false
         type: "string"
+
       with-chromatic:
         description: "Determines whether to publish the Storybook to Chromatic."
         required: false
@@ -17,6 +18,11 @@ on:
         description: 'Flag to enable Npm setup with GitHub Packages.'
         required: false
         default: 'true'
+        type: "string"
+
+      base-dir:
+        description: "The base directory of the Node.js project."
+        required: false
         type: "string"
 
       storybook-dir:
@@ -93,7 +99,7 @@ jobs:
     uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@5805c22d818c20b9b0077096a021c1161c1cf7f8
     with:
       make-file: ${{ inputs.make-file }}
-      base-dir: ${{ inputs.storybook-dir }}
+      base-dir: ${{ inputs.base-dir }}
       artifact-name: ${{ inputs.storybook-static-dir }}
       artifact-path: ${{ inputs.storybook-dir }}${{ inputs.storybook-static-dir-separator }}${{ inputs.storybook-static-dir }}
       with-setup-npm-github-pkg: ${{ inputs.with-setup-npm-github-pkg }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@main
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@a8793d91302765c5dafd755d82bb0bcf9ad2b142
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}
@@ -147,7 +147,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@main
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@a8793d91302765c5dafd755d82bb0bcf9ad2b142
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -128,7 +128,7 @@ jobs:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}
       - name: Publish Storybook to Chromatic
-        uses: komune-io/fixers-gradle/.github/actions/chromatic@main
+        uses: komune-io/fixers-gradle/.github/actions/chromatic@0065aac54607100431891653e7fd0c4808d12dbb
         with:
           storybook-dir: ${{ inputs.storybook-dir }}
           storybook-static-dir: ${{ inputs.storybook-static-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -96,7 +96,7 @@ on:
 
 jobs:
   package-storybook:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@5805c22d818c20b9b0077096a021c1161c1cf7f8
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@541f8c4e459f3e208cd531c1e97917ad19abde26
     with:
       make-file: ${{ inputs.make-file }}
       base-dir: ${{ inputs.base-dir }}
@@ -129,12 +129,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@5805c22d818c20b9b0077096a021c1161c1cf7f8
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@541f8c4e459f3e208cd531c1e97917ad19abde26
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}
       - name: Publish Storybook to Chromatic
-        uses: komune-io/fixers-gradle/.github/actions/chromatic@0065aac54607100431891653e7fd0c4808d12dbb
+        uses: komune-io/fixers-gradle/.github/actions/chromatic@541f8c4e459f3e208cd531c1e97917ad19abde26
         with:
           storybook-dir: ${{ inputs.storybook-dir }}
           storybook-static-dir: ${{ inputs.storybook-static-dir }}
@@ -153,7 +153,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@beb8afdc4eb334c90cbada0a4a2571f17d02515d
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@541f8c4e459f3e208cd531c1e97917ad19abde26
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@7cfd6da9011be3c241632d32b56e4ea82bf201a4
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@ea5bf711da9bdb237d239a4c60916f2741bc0fb8
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}
@@ -147,7 +147,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@7cfd6da9011be3c241632d32b56e4ea82bf201a4
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@ea5bf711da9bdb237d239a4c60916f2741bc0fb8
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@ea5bf711da9bdb237d239a4c60916f2741bc0fb8
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@beb8afdc4eb334c90cbada0a4a2571f17d02515d
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}
@@ -147,7 +147,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages
-        uses: komune-io/fixers-gradle/.github/actions/nodejs@ea5bf711da9bdb237d239a4c60916f2741bc0fb8
+        uses: komune-io/fixers-gradle/.github/actions/nodejs@beb8afdc4eb334c90cbada0a4a2571f17d02515d
         with:
           node-version: ${{ inputs.node-version }}
           base-dir: ${{ inputs.storybook-dir }}


### PR DESCRIPTION
 The Node.js GitHub Action now automatically detects the package manager being used (npm, yarn, or pnpm) and adjusts the caching strategy accordingly. This improves the workflow's flexibility and efficiency by ensuring
   that the correct dependencies are cached based on the project's configuration, reducing build times and potential errors.

  ## Changes Made

  - **Automatic Package Manager Detection**: Added detection step that checks for lockfiles in priority order:
    - `pnpm-lock.yaml` → pnpm
    - `yarn.lock` → yarn
    - `package-lock.json` → npm
    - Defaults to yarn if no lockfile found

  - **Dynamic Cache Configuration**: Updated `actions/setup-node@v4` to use the detected package manager for caching

  - **Package Manager Specific Caching**: Added conditional caching strategies for each package manager:
    - **pnpm**: Caches `~/.pnpm-store` and `**/node_modules`
    - **yarn**: Caches `**/node_modules` (existing behavior)
    - **npm**: Caches `**/node_modules`

  - **Updated Documentation**: Modified action description to mention automatic package manager detection