### PR TITLE
chore(ci): update GitHub Actions workflow to include JReleaser credentials and improve tag handling

### DIFF
--- a/.github/actions/setup-gradle-github-pkg/action.yml
+++ b/.github/actions/setup-gradle-github-pkg/action.yml
@@ -13,7 +13,7 @@ runs:
         echo "settingsEvaluated {
             pluginManagement {
                 repositories {
-                    mavenLocal()
+                    mavenCentral()
                     gradlePluginPortal()
                     maven {
                         url = uri(\"https://maven.pkg.github.com/komune-io/fixers\")
@@ -27,7 +27,6 @@ runs:
         }
         allprojects {
             repositories {
-                mavenLocal()
                 mavenCentral()
                 maven {
                     url = uri(\"https://maven.pkg.github.com/komune-io/fixers\")

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,6 +25,8 @@ jobs:
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
 
   docs:
     uses: ./.github/workflows/publish-storybook-workflow.yml
@@ -34,10 +36,12 @@ jobs:
       pages: write
       id-token: write
     with:
-      on-tag: 'stage_promote'
+      on-tag: 'stage promote'
+      make-file: 'make_docs.mk'
       with-chromatic: false
-      storybook-dir: storybook
-      storybook-static-dir: storybook-static
+      base-dir: "storybook"
+      storybook-dir: "storybook"
+      storybook-static-dir: "storybook-static"
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,6 +27,9 @@ jobs:
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
       JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
+      PKG_GITHUB_USERNAME: ${{ github.actor }}
+      PKG_GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   docs:
     uses: ./.github/workflows/publish-storybook-workflow.yml


### PR DESCRIPTION
The workflow now includes JReleaser credentials for publishing to Maven Central, enhancing the deployment process. Additionally, the tag handling is improved by changing 'stage_promote' to 'stage promote' for better clarity and consistency. The make-file parameter is also added to streamline the documentation generation process.