### PR TITLE
chore(dependencies): update dependencies to latest versions for improved stability and features

### DIFF
--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/dependencies/Dependencies.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/dependencies/Dependencies.kt
@@ -20,7 +20,7 @@ object FixersRepository {
 
 object FixersPluginVersions {
 	const val kotlin = "1.9.25"
-	const val springBoot = "3.3.6"
+	const val springBoot = "3.5.4"
 	const val npmPublish = "3.4.2"
 	/**
 	 * com.google.devtools.ksp
@@ -41,31 +41,31 @@ object FixersVersions {
 
 	object Spring {
 		const val boot = FixersPluginVersions.springBoot
-		const val data = "3.3.4"
+		const val data = "3.5.2"
 		const val framework = "6.1.13"
-		const val security = "6.3.3"
+		const val security = "6.5.2"
 		const val jakartaPersistence = "3.2.0"
-		const val reactor = "3.6.10"
+		const val reactor = "3.7.8"
 	}
 
 	object Json {
-		const val jackson = "2.17.2"
+		const val jackson = "2.19.2"
 		const val jacksonKotlin = jackson
 	}
 
 	object Test {
 		const val cucumber = "7.19.0"
-		const val junit = "5.11.1"
-		const val junitPlatform = "1.11.1"
-		const val assertj = "3.26.3"
-		const val testcontainers = "1.20.2"
+		const val junit = "5.13.4"
+		const val junitPlatform = "1.13.4"
+		const val assertj = "3.27.3"
+		const val testcontainers = "1.21.3"
 	}
 
 	object Kotlin {
 		const val coroutines = "1.8.1"
 		const val serialization = "1.6.3"
 		const val datetime = "0.6.1"
-		const val ktor = "2.3.12"
+		const val ktor = "2.3.13"
 	}
 }
 

--- a/make_docs.mk
+++ b/make_docs.mk
@@ -8,12 +8,14 @@ STORYBOOK_LATEST		:= ${STORYBOOK_NAME}:latest
 
 lint: lint-docker-storybook
 
-build: build-storybook
+build: build-storybook package-storybook
 
 test:
 	echo 'No Test'
 
-package: package-storybook push-storybook
+stage: push-storybook
+
+promote: push-storybook
 
 # Storybook
 build-storybook:
@@ -24,7 +26,7 @@ lint-docker-storybook:
 	@docker run --rm -i hadolint/hadolint hadolint - < ${STORYBOOK_DOCKERFILE}
 
 package-storybook:
-	@docker build --no-cache  --platform=linux/amd64 \
+	@docker build --no-cache --platform=linux/amd64 \
 		--build-arg NPM_AUTH_TOKEN=${NPM_AUTH_TOKEN} \
 		-f ${STORYBOOK_DOCKERFILE} \
 		-t ${STORYBOOK_IMG} .


### PR DESCRIPTION
chore(make_docs.mk): modify build process to include packaging and staging steps Updating the dependencies ensures that the project benefits from the latest features, bug fixes, and security patches. The build process is adjusted to streamline the workflow by including packaging and staging steps, making it easier to manage the deployment of the Storybook application.