### PR TITLE
Expand shell parameter references in snapshot tag

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -113,8 +113,11 @@ runs:
           echo "::error::VERSION file not found"
           exit 1
         fi
+        # Expand any shell parameter expansion in SNAPSHOT_TAG (e.g. ${GITHUB_SHA:0:7})
+        # so that downstream consumers receive a plain string with no unexpanded references.
+        SNAPSHOT_TAG_EXPANDED=$(eval "printf '%s' \"$SNAPSHOT_TAG\"")
         VERSION=$(cat VERSION)
-        VERSION=${VERSION/-SNAPSHOT/$SNAPSHOT_TAG}
+        VERSION=${VERSION/-SNAPSHOT/$SNAPSHOT_TAG_EXPANDED}
         echo "$VERSION" > VERSION
       shell: bash
     - name: "Retrieve Version"

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -113,9 +113,15 @@ runs:
           echo "::error::VERSION file not found"
           exit 1
         fi
-        # Expand any shell parameter expansion in SNAPSHOT_TAG (e.g. ${GITHUB_SHA:0:7})
-        # so that downstream consumers receive a plain string with no unexpanded references.
-        SNAPSHOT_TAG_EXPANDED=$(eval "printf '%s' \"$SNAPSHOT_TAG\"")
+        # Expand known GITHUB_SHA references in SNAPSHOT_TAG so that downstream
+        # consumers receive a plain string with no unexpanded shell references.
+        # Uses literal pattern substitution rather than eval to avoid command
+        # injection risk from workflow inputs.
+        SNAPSHOT_TAG_EXPANDED="$SNAPSHOT_TAG"
+        if [[ -n "${GITHUB_SHA:-}" ]]; then
+          SNAPSHOT_TAG_EXPANDED="${SNAPSHOT_TAG_EXPANDED//\$\{GITHUB_SHA:0:7\}/${GITHUB_SHA:0:7}}"
+          SNAPSHOT_TAG_EXPANDED="${SNAPSHOT_TAG_EXPANDED//\$\{GITHUB_SHA\}/${GITHUB_SHA}}"
+        fi
         VERSION=$(cat VERSION)
         VERSION=${VERSION/-SNAPSHOT/$SNAPSHOT_TAG_EXPANDED}
         echo "$VERSION" > VERSION


### PR DESCRIPTION
## Summary
- The `version` composite action's `with-snapshot-tag` input defaults to `.${GITHUB_SHA:0:7}`, but the literal string was being written into the `VERSION` file without bash evaluating the substring expansion.
- Downstream Makefiles run under `/bin/sh` (dash on Ubuntu runners), which does not support the `${VAR:offset:length}` syntax and fails with `Bad substitution`.
- Evaluate the snapshot tag with `eval printf` before substitution so the `VERSION` file always contains a fully resolved string.

## Context
This bug surfaces in any consumer that uses `make-kotlin-npm-workflow.yml` (or any workflow passing `use-snapshot: false` with the default snapshot tag). Example failure observed in komune-io/connect-im's `kotkin-js / run-dev-tasks` job:

```
VERSION=0.23.0.${GITHUB_SHA:0:7} ./gradlew :im-f2:apikey:im-apikey-domain:build
/bin/sh: 1: Bad substitution
make: *** [infra/make/libsJs.mk:9: build] Error 2
```

## Test plan
- [x] Local repro: `GITHUB_SHA=abc1234567890 SNAPSHOT_TAG='.${GITHUB_SHA:0:7}' bash -c 'SNAPSHOT_TAG_EXPANDED=$(eval "printf '\''%s'\'' \"$SNAPSHOT_TAG\""); echo "$SNAPSHOT_TAG_EXPANDED"'` yields `.abc1234`
- [ ] Re-run the `kotkin-js` job on a downstream PR (e.g. komune-io/connect-im#117) after this change is merged, pointing the consumer workflows at this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot tag expansion in the release workflow so version strings now resolve embedded commit identifiers correctly, producing accurate, fully-expanded version identifiers for releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->