### PR TITLE
fix(npm): per-registry authToken + workflow rename

### DIFF
--- a/.github/workflows/make-kotlin-npm-workflow.yml
+++ b/.github/workflows/make-kotlin-npm-workflow.yml
@@ -97,9 +97,7 @@ on:
         required: false
       PKG_SONATYPE_OSS_TOKEN:
         required: false
-      NPM_PKG_STAGE_TOKEN:
-        required: false
-      NPM_PKG_PROMOTE_TOKEN:
+      FIXERS_PUBLISH_NPMJS_TOKEN:
         required: false
 
 jobs:
@@ -161,7 +159,7 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_PKG_STAGE_TOKEN }}
+          FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Execute Make Check Task
         if: (contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
@@ -177,7 +175,7 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-promote-task }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_PKG_PROMOTE_TOKEN }}
+          FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -127,8 +127,6 @@ on:
         required: false
       DOCKER_PROMOTE_PASSWORD:
         required: false
-      NPM_PKG_GITHUB_TOKEN:
-        required: false
       NPM_PKG_NPMJS_TOKEN:
         required: false
 
@@ -136,8 +134,6 @@ jobs:
   run-dev-tasks:
     if: (github.event_name == 'pull_request' && !startsWith(github.head_ref, inputs.excluded-versioning-branch)) || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    env:
-      NPM_PKG_GITHUB_TOKEN: ${{ secrets.NPM_PKG_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -154,7 +150,7 @@ jobs:
         id: setup_npm_github_pkg
         uses: komune-io/fixers-gradle/.github/actions/setup-npm-github-pkg@main
         with:
-          npm-auth-token: ${{ secrets.NPM_PKG_GITHUB_TOKEN }}
+          npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Version from File
         uses: komune-io/fixers-gradle/.github/actions/version@main

--- a/.github/workflows/mise-kotlin-npm-workflow.yml
+++ b/.github/workflows/mise-kotlin-npm-workflow.yml
@@ -78,9 +78,7 @@ on:
         required: false
       PKG_GITHUB_TOKEN:
         required: false
-      NPM_PKG_STAGE_TOKEN:
-        required: false
-      NPM_PKG_PROMOTE_TOKEN:
+      FIXERS_PUBLISH_NPMJS_TOKEN:
         required: false
 
 jobs:
@@ -132,7 +130,7 @@ jobs:
         with:
           mise-task: ${{ inputs.mise-stage-task }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_PKG_STAGE_TOKEN }}
+          FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Execute Mise Check Task
         if: (contains(inputs.on-tag, inputs.mise-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
@@ -146,7 +144,7 @@ jobs:
         with:
           mise-task: ${{ inputs.mise-promote-task }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_PKG_PROMOTE_TOKEN }}
+          FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''

--- a/.github/workflows/mise-nodejs-workflow.yml
+++ b/.github/workflows/mise-nodejs-workflow.yml
@@ -121,8 +121,6 @@ on:
         required: false
       DOCKER_PROMOTE_PASSWORD:
         required: false
-      NPM_PKG_GITHUB_TOKEN:
-        required: false
       NPM_PKG_NPMJS_TOKEN:
         required: false
 
@@ -130,8 +128,6 @@ jobs:
   run-dev-tasks:
     if: (github.event_name == 'pull_request' && !startsWith(github.head_ref, inputs.excluded-versioning-branch)) || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    env:
-      NPM_PKG_GITHUB_TOKEN: ${{ secrets.NPM_PKG_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -151,7 +147,7 @@ jobs:
         id: setup_npm_github_pkg
         uses: komune-io/fixers-gradle/.github/actions/setup-npm-github-pkg@main
         with:
-          npm-auth-token: ${{ secrets.NPM_PKG_GITHUB_TOKEN }}
+          npm-auth-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Version from File
         uses: komune-io/fixers-gradle/.github/actions/version@main

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/PublishConfig.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/PublishConfig.kt
@@ -28,6 +28,8 @@ open class PublishConfig(
                 pkgGithubToken=******,
                 signingGpgKey=******,
                 signingGpgKeyPassword=******,
+                npmjsToken=******,
+                npmGithubToken=******,
                 gradlePlugin=${gradlePlugin.orNull},
                 gradlePluginPortalEnabled=${gradlePluginPortalEnabled.orNull},
                 stagingDirectory=${stagingDirectory.orNull},
@@ -102,6 +104,25 @@ open class PublishConfig(
     )
 
     /**
+     * npmjs automation token for `@komune-io` scope publishes from `NpmPlugin`.
+     * Bound to the `npmjs` registry in the npm-publish extension.
+     */
+    val npmjsToken: Property<String> = project.property(
+        envKey = "FIXERS_PUBLISH_NPMJS_TOKEN",
+        projectKey = "fixers.publish.npmjs.token"
+    )
+
+    /**
+     * GitHub Packages npm token for `@komune-io` scope publishes from `NpmPlugin`.
+     * Bound to the `github` registry in the npm-publish extension.
+     * In CI, sourced directly from the auto-forwarded `GITHUB_TOKEN` via reusable workflows.
+     */
+    val npmGithubToken: Property<String> = project.property(
+        envKey = "FIXERS_PUBLISH_NPM_GITHUB_TOKEN",
+        projectKey = "fixers.publish.npm.github.token"
+    )
+
+    /**
      * List of marker publications for Gradle plugins.
      */
     val gradlePlugin: ListProperty<String> = project.objects.listProperty(String::class.java).apply {
@@ -173,6 +194,8 @@ open class PublishConfig(
         pkgGithubToken.mergeIfNotPresent(source.pkgGithubToken)
         signingGpgKey.mergeIfNotPresent(source.signingGpgKey)
         signingGpgKeyPassword.mergeIfNotPresent(source.signingGpgKeyPassword)
+        npmjsToken.mergeIfNotPresent(source.npmjsToken)
+        npmGithubToken.mergeIfNotPresent(source.npmGithubToken)
         stagingDirectory.mergeIfNotPresent(source.stagingDirectory)
         githubPackagesUrl.mergeIfNotPresent(source.githubPackagesUrl)
         gradlePluginPortalEnabled.mergeIfNotPresent(source.gradlePluginPortalEnabled)

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/npm/NpmPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/npm/NpmPlugin.kt
@@ -13,9 +13,15 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.the
 
 /**
- * Applies `dev.petuska.npm.publish` with Komune conventions: two registries (npmjs,
- * GitHub Packages) authenticated via `$NPM_TOKEN`, a `kt2Ts` cleanup task wired
- * before every publish, and a dist-tag policy for prerelease versions.
+ * Applies `dev.petuska.npm.publish` with Komune conventions: two registries authenticated
+ * via per-registry tokens sourced from `PublishConfig`, a `kt2Ts` cleanup task wired before
+ * every publish, and a dist-tag policy for prerelease versions.
+ *
+ * Registry → token mapping:
+ *   - `npmjs` (https://registry.npmjs.org) → `config.publish.npmjsToken`,
+ *     env `$FIXERS_PUBLISH_NPMJS_TOKEN` or gradle prop `fixers.publish.npmjs.token`
+ *   - `github` (https://npm.pkg.github.com) → `config.publish.npmGithubToken`,
+ *     env `$FIXERS_PUBLISH_NPM_GITHUB_TOKEN` or gradle prop `fixers.publish.npm.github.token`
  *
  * Dist-tag policy:
  *   - release versions (no `-` in the semver) → npm default `latest`
@@ -62,8 +68,9 @@ class NpmPlugin : Plugin<Project> {
 	private fun Project.configureNpmPublishPlugin(config: ConfigExtension) {
 		logger.info("Apply NpmPublishPlugin to ${this.name}")
 		project.pluginManager.apply(NpmPublishPlugin::class.java)
-		// Use providers.environmentVariable() for configuration cache compatibility
-		val npmToken = providers.environmentVariable("NPM_TOKEN")
+		// Per-registry tokens read from PublishConfig (env/gradle-prop fallback chain).
+		val npmjsToken = config.publish.npmjsToken
+		val npmGithubToken = config.publish.npmGithubToken
 		val effectiveVersion = config.npm.version.orNull ?: project.version.toString()
 		project.the<NpmPublishExtension>().apply {
 			organization.set(config.npm.organization.get())
@@ -71,11 +78,11 @@ class NpmPlugin : Plugin<Project> {
 			registries {
 				register("npmjs") {
 					uri.set(uri("https://registry.npmjs.org"))
-					authToken.set(npmToken)
+					authToken.set(npmjsToken)
 				}
 				register("github") {
 					uri.set(uri("https://npm.pkg.github.com"))
-					authToken.set(npmToken)
+					authToken.set(npmGithubToken)
 				}
 			}
 		}

--- a/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/npm/NpmPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/npm/NpmPluginIntegrationTest.kt
@@ -413,14 +413,20 @@ class NpmPluginIntegrationTest : BaseIntegrationTest() {
             "-Pfixers.publish.npm.github.token=github-token-value"
         )
 
-        assertThat(result.task(":verifyNpmRegistryTokens")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        // The npmjs registry must receive the npmjs-specific token.
-        assertThat(result.output).contains("registry=npmjs uri=https://registry.npmjs.org token=npmjs-token-value")
-        // The github registry must receive the github-specific token.
-        assertThat(result.output).contains("registry=github uri=https://npm.pkg.github.com token=github-token-value")
-        // Neither registry should have the opposite token bound (guards against the legacy
-        // single-token wiring that assigned the same value to both).
-        assertThat(result.output).doesNotContain("registry=npmjs uri=https://registry.npmjs.org token=github-token-value")
-        assertThat(result.output).doesNotContain("registry=github uri=https://npm.pkg.github.com token=npmjs-token-value")
+        assertThat(result.task(":verifyNpmRegistryTokens")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains(
+            "registry=npmjs uri=https://registry.npmjs.org token=npmjs-token-value"
+        )
+        assertThat(result.output).contains(
+            "registry=github uri=https://npm.pkg.github.com token=github-token-value"
+        )
+        // Neither registry should have the opposite token bound.
+        assertThat(result.output).doesNotContain(
+            "registry=npmjs uri=https://registry.npmjs.org token=github-token-value"
+        )
+        assertThat(result.output).doesNotContain(
+            "registry=github uri=https://npm.pkg.github.com token=npmjs-token-value"
+        )
     }
 }

--- a/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/npm/NpmPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/npm/NpmPluginIntegrationTest.kt
@@ -347,8 +347,6 @@ class NpmPluginIntegrationTest : BaseIntegrationTest() {
      */
     private fun createTokenWiringBuildFile() {
         writeBuildFile("""
-            import dev.petuska.npm.publish.extension.NpmPublishExtension
-
             plugins {
                 id("io.komune.fixers.gradle.config")
                 id("io.komune.fixers.gradle.kotlin.mpp")
@@ -380,8 +378,8 @@ class NpmPluginIntegrationTest : BaseIntegrationTest() {
             }
 
             tasks.register("verifyNpmRegistryTokens") {
-                val npmExt = extensions.getByType(NpmPublishExtension::class.java)
                 doLast {
+                    val npmExt = project.the<dev.petuska.npm.publish.extension.NpmPublishExtension>()
                     npmExt.registries.all {
                         val tokenValue = if (authToken.isPresent) authToken.get() else "<unset>"
                         println("registry=${'$'}{name} uri=${'$'}{uri.get()} token=${'$'}{tokenValue}")

--- a/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/npm/NpmPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/npm/NpmPluginIntegrationTest.kt
@@ -339,4 +339,88 @@ class NpmPluginIntegrationTest : BaseIntegrationTest() {
         assertThat(result.output).doesNotContain("tag: next")
         assertThat(result.output).doesNotContain("tag: <unset>")
     }
+
+    /**
+     * Creates a build file that exposes the per-registry `authToken` values configured by
+     * NpmPlugin on the `NpmPublishExtension`. Drives the assertion in
+     * [`should bind per-registry tokens from PublishConfig`].
+     */
+    private fun createTokenWiringBuildFile() {
+        writeBuildFile("""
+            import dev.petuska.npm.publish.extension.NpmPublishExtension
+
+            plugins {
+                id("io.komune.fixers.gradle.config")
+                id("io.komune.fixers.gradle.kotlin.mpp")
+                id("io.komune.fixers.gradle.npm")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            fixers {
+                bundle {
+                    id = "test-bundle"
+                    name = "Test Bundle"
+                    description = "A test bundle for integration testing"
+                    url = "https://github.com/komune-io/fixers-gradle"
+                }
+                npm {
+                    publish = true
+                    organization = "test-organization"
+                }
+            }
+
+            kotlin {
+                js(IR) {
+                    browser()
+                    nodejs()
+                }
+            }
+
+            tasks.register("verifyNpmRegistryTokens") {
+                val npmExt = extensions.getByType(NpmPublishExtension::class.java)
+                doLast {
+                    npmExt.registries.all {
+                        val tokenValue = if (authToken.isPresent) authToken.get() else "<unset>"
+                        println("registry=${'$'}{name} uri=${'$'}{uri.get()} token=${'$'}{tokenValue}")
+                    }
+                }
+            }
+        """.trimIndent())
+    }
+
+    /**
+     * Test that NpmPlugin binds `config.publish.npmjsToken` to the `npmjs` registry and
+     * `config.publish.npmGithubToken` to the `github` registry, rather than the legacy
+     * single-`NPM_TOKEN`-for-both-registries wiring.
+     *
+     * Tokens are sourced via gradle properties (`fixers.publish.npmjs.token` /
+     * `fixers.publish.npm.github.token`), exercising the `project.property()` fallback
+     * chain from env → gradle prop. CI uses the env var path; this test uses the prop
+     * path because `GradleRunner` doesn't expose a clean way to set env vars per-run.
+     */
+    @Test
+    fun `should bind per-registry tokens from PublishConfig`() {
+        createJsSourceFile()
+        createBasicPackageJson()
+        createTokenWiringBuildFile()
+
+        val result = runGradle(
+            "verifyNpmRegistryTokens",
+            "-Pfixers.publish.npmjs.token=npmjs-token-value",
+            "-Pfixers.publish.npm.github.token=github-token-value"
+        )
+
+        assertThat(result.task(":verifyNpmRegistryTokens")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        // The npmjs registry must receive the npmjs-specific token.
+        assertThat(result.output).contains("registry=npmjs uri=https://registry.npmjs.org token=npmjs-token-value")
+        // The github registry must receive the github-specific token.
+        assertThat(result.output).contains("registry=github uri=https://npm.pkg.github.com token=github-token-value")
+        // Neither registry should have the opposite token bound (guards against the legacy
+        // single-token wiring that assigned the same value to both).
+        assertThat(result.output).doesNotContain("registry=npmjs uri=https://registry.npmjs.org token=github-token-value")
+        assertThat(result.output).doesNotContain("registry=github uri=https://npm.pkg.github.com token=npmjs-token-value")
+    }
 }


### PR DESCRIPTION
## Summary
- `PublishConfig`: add `npmjsToken` / `npmGithubToken` fields via `project.property()` helper
- `NpmPlugin`: read per-registry tokens from `PublishConfig` instead of single `NPM_TOKEN` env var
- `NpmPluginIntegrationTest`: new test asserting per-registry authToken binding
- Kotlin-NPM workflows: rename `NPM_PKG_PROMOTE_TOKEN` → `FIXERS_PUBLISH_NPMJS_TOKEN`, delete `NPM_PKG_STAGE_TOKEN` (stage step reads `secrets.GITHUB_TOKEN` directly)
- NodeJS workflows: delete `NPM_PKG_GITHUB_TOKEN` declaration + job env, action reads `secrets.GITHUB_TOKEN` directly

## Test plan
- [ ] `gradle -p plugin test --tests "*NpmPluginIntegration*"` passes
- [ ] Dry-run `FIXERS_PUBLISH_NPMJS_TOKEN=dummy gradle :publishJsPackageToNpmjsRegistry --dry-run`
- [ ] CI: connect-im kotkin-js job completes after org secret `NPM_PKG_NPMJS_TOKEN` is rotated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish tooling now supports per-registry authentication tokens (separate tokens for npmjs and GitHub Packages).
* **Chores**
  * CI workflows and publishing flows updated to use the per-registry token model and to source the appropriate GitHub token.
* **Tests**
  * Added an integration test that verifies per-registry tokens are wired and applied during npm publish steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->