### PR TITLE
feat(ci): normalize all secrets to FIXERS_PUBLISH_* / FIXERS_* namespace

### DIFF
--- a/.github/actions/setup-gradle-github-pkg/action.yml
+++ b/.github/actions/setup-gradle-github-pkg/action.yml
@@ -18,8 +18,8 @@ runs:
                     maven {
                         url = uri(\"https://maven.pkg.github.com/komune-io/fixers\")
                         credentials {
-                            username = System.getenv(\"PKG_GITHUB_USERNAME\")
-                            password = System.getenv(\"PKG_GITHUB_TOKEN\")
+                            username = System.getenv(\"FIXERS_PUBLISH_GITHUB_USERNAME\") ?: System.getenv(\"PKG_GITHUB_USERNAME\")
+                            password = System.getenv(\"FIXERS_PUBLISH_GITHUB_TOKEN\") ?: System.getenv(\"PKG_GITHUB_TOKEN\")
                         }
                     }
                 }

--- a/.github/actions/setup-gradle-github-pkg/action.yml
+++ b/.github/actions/setup-gradle-github-pkg/action.yml
@@ -18,8 +18,8 @@ runs:
                     maven {
                         url = uri(\"https://maven.pkg.github.com/komune-io/fixers\")
                         credentials {
-                            username = System.getenv(\"FIXERS_PUBLISH_GITHUB_USERNAME\") ?: System.getenv(\"PKG_GITHUB_USERNAME\")
-                            password = System.getenv(\"FIXERS_PUBLISH_GITHUB_TOKEN\") ?: System.getenv(\"PKG_GITHUB_TOKEN\")
+                            username = System.getenv(\"FIXERS_PUBLISH_GITHUB_USERNAME\")
+                            password = System.getenv(\"FIXERS_PUBLISH_GITHUB_TOKEN\")
                         }
                     }
                 }
@@ -31,8 +31,8 @@ runs:
                 maven {
                     url = uri(\"https://maven.pkg.github.com/komune-io/fixers\")
                     credentials {
-                        username = System.getenv(\"PKG_GITHUB_USERNAME\")
-                        password = System.getenv(\"PKG_GITHUB_TOKEN\")
+                        username = System.getenv(\"FIXERS_PUBLISH_GITHUB_USERNAME\")
+                        password = System.getenv(\"FIXERS_PUBLISH_GITHUB_TOKEN\")
                     }
                 }
             }

--- a/.github/actions/setup-npm-github-pkg/action.yml
+++ b/.github/actions/setup-npm-github-pkg/action.yml
@@ -18,11 +18,11 @@ runs:
     - id: setup_npm
       env:
         NPM_REGISTRY: ${{ inputs.npm-registry }}
-        NPM_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ inputs.npm-auth-token }}
       run: |
         echo "
           @komune-io:registry=https://${NPM_REGISTRY}
-          //${NPM_REGISTRY}/:_authToken=${NPM_AUTH_TOKEN}
+          //${NPM_REGISTRY}/:_authToken=${FIXERS_PUBLISH_NPM_GITHUB_TOKEN}
         " > .npmrc
       shell: bash
     - id: set_output

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,17 +21,17 @@ jobs:
     with:
       make-file: 'infra/make/libs.mk'
     secrets:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_GRADLE_PORTAL_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY }}
+      FIXERS_PUBLISH_GRADLE_PORTAL_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET }}
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
 
   sec:
     needs: dev
@@ -40,5 +40,5 @@ jobs:
       contents: write  # Required for gradle dependency-submission
       pull-requests: read  # Required for sonarcloud PR analysis
     secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
 

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -185,13 +185,13 @@ jobs:
       # TODO(normalize-secrets): drop after one release cycle.
       PKG_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME }}
       PKG_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN }}
-      # Non-plugin consumers read these step-level env var names directly:
-      # - sonarqube-scan-action@v7 reads SONAR_TOKEN
-      # - com.gradle.plugin-publish reads GRADLE_PUBLISH_KEY/SECRET at gradle runtime
-      # Source values use new FIXERS_* names with legacy fallback.
+      # sonarqube-scan-action@v7 reads SONAR_TOKEN env var directly.
       SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
-      GRADLE_PUBLISH_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY || secrets.GRADLE_PUBLISH_KEY }}
-      GRADLE_PUBLISH_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET || secrets.GRADLE_PUBLISH_SECRET }}
+      # Gradle Plugin Portal credentials: PublishPlugin.kt bridges these env vars
+      # to the `gradle.publish.key`/`gradle.publish.secret` system properties that
+      # `com.gradle.plugin-publish` reads at task-execution time.
+      FIXERS_PUBLISH_GRADLE_PORTAL_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY || secrets.GRADLE_PUBLISH_KEY }}
+      FIXERS_PUBLISH_GRADLE_PORTAL_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET || secrets.GRADLE_PUBLISH_SECRET }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -161,8 +161,9 @@ jobs:
       FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
-      # sonarqube-scan-action@v7 reads SONAR_TOKEN env var directly.
-      SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
+      # CheckPlugin.bridgeSonarToken() reads FIXERS_SONAR_TOKEN and sets the
+      # `sonar.token` system property for the gradle sonarqube plugin.
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
       # Gradle Plugin Portal credentials: PublishPlugin.kt bridges these env vars
       # to the `gradle.publish.key`/`gradle.publish.secret` system properties that
       # `com.gradle.plugin-publish` reads at task-execution time.

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -133,12 +133,9 @@ on:
         required: false
       FIXERS_SONAR_TOKEN:
         required: false
-      FIXERS_DOCKER_HUB_USERNAME:
-        required: false
-      FIXERS_DOCKER_HUB_PASSWORD:
-        required: false
       # Docker registry login inputs — these are the workflow's own input names
-      # for the docker/login-action step, not legacy aliases.
+      # for the docker/login-action step. Callers map their org secrets
+      # (e.g. FIXERS_DOCKER_HUB_USERNAME) to these input names.
       DOCKER_STAGE_USERNAME:
         required: false
       DOCKER_STAGE_PASSWORD:

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -158,12 +158,12 @@ jobs:
       FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
-      # CheckPlugin.bridgeSonarToken() reads FIXERS_SONAR_TOKEN and sets the
-      # `sonar.token` system property for the gradle sonarqube plugin.
+      # SonarQubeConfigurator reads FIXERS_SONAR_TOKEN and sets sonar.token
+      # via the sonarqube extension DSL.
       FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
       # Gradle Plugin Portal credentials: PublishPlugin.kt bridges these env vars
-      # to the `gradle.publish.key`/`gradle.publish.secret` system properties that
-      # `com.gradle.plugin-publish` reads at task-execution time.
+      # to the `gradle.publish.key`/`gradle.publish.secret` Gradle project properties
+      # (via extraProperties) that `com.gradle.plugin-publish` reads at task-execution time.
       FIXERS_PUBLISH_GRADLE_PORTAL_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY }}
       FIXERS_PUBLISH_GRADLE_PORTAL_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET }}
     steps:

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -115,6 +115,30 @@ on:
         default: 'false'
 
     secrets:
+      FIXERS_PUBLISH_SIGNING_GPG_KEY:
+        required: false
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD:
+        required: false
+      FIXERS_PUBLISH_GITHUB_USERNAME:
+        required: false
+      FIXERS_PUBLISH_GITHUB_TOKEN:
+        required: false
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME:
+        required: false
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD:
+        required: false
+      FIXERS_PUBLISH_GRADLE_PORTAL_KEY:
+        required: false
+      FIXERS_PUBLISH_GRADLE_PORTAL_SECRET:
+        required: false
+      FIXERS_SONAR_TOKEN:
+        required: false
+      FIXERS_DOCKER_HUB_USERNAME:
+        required: false
+      FIXERS_DOCKER_HUB_PASSWORD:
+        required: false
+      # Legacy names — kept for one release cycle for backwards compatibility.
+      # TODO(normalize-secrets): remove after all consumers migrate.
       GPG_SIGNING_KEY:
         required: false
       GPG_SIGNING_PASSWORD:
@@ -147,24 +171,27 @@ jobs:
     if: (github.event_name == 'pull_request' && !startsWith(github.head_ref, inputs.excluded-versioning-branch)) || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     env:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      JRELEASER_DEPLOY_MAVEN_NEXUS2_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_DEPLOY_MAVEN_NEXUS2_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      JRELEASER_DEPLOY_MAVEN_GITHUB_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
-      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
-      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
-      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+      # Primary FIXERS_PUBLISH_* names read by Kotlin plugin and gradle tasks.
+      # Use new secret names first, fall back to legacy names during transition.
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY || secrets.GPG_SIGNING_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME || secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD || secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
+      # Legacy names — kept for composite actions (setup-gradle-github-pkg) that
+      # still read System.getenv("PKG_GITHUB_*") with fallback. Also needed until
+      # all consumer repos migrate their caller-side pass-throughs.
+      # TODO(normalize-secrets): drop after one release cycle.
+      PKG_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN }}
+      # Non-plugin consumers read these step-level env var names directly:
+      # - sonarqube-scan-action@v7 reads SONAR_TOKEN
+      # - com.gradle.plugin-publish reads GRADLE_PUBLISH_KEY/SECRET at gradle runtime
+      # Source values use new FIXERS_* names with legacy fallback.
+      SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
+      GRADLE_PUBLISH_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY || secrets.GRADLE_PUBLISH_KEY }}
+      GRADLE_PUBLISH_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET || secrets.GRADLE_PUBLISH_SECRET }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -137,16 +137,8 @@ on:
         required: false
       FIXERS_DOCKER_HUB_PASSWORD:
         required: false
-      # Legacy names — kept for one release cycle for backwards compatibility.
-      # TODO(normalize-secrets): remove after all consumers migrate.
-      GPG_SIGNING_KEY:
-        required: false
-      GPG_SIGNING_PASSWORD:
-        required: false
-      PKG_GITHUB_USERNAME:
-        required: false
-      PKG_GITHUB_TOKEN:
-        required: false
+      # Docker registry login inputs — these are the workflow's own input names
+      # for the docker/login-action step, not legacy aliases.
       DOCKER_STAGE_USERNAME:
         required: false
       DOCKER_STAGE_PASSWORD:
@@ -155,43 +147,27 @@ on:
         required: false
       DOCKER_PROMOTE_PASSWORD:
         required: false
-      JRELEASER_MAVENCENTRAL_USERNAME:
-        required: false
-      JRELEASER_MAVENCENTRAL_PASSWORD:
-        required: false
-      SONAR_TOKEN:
-        required: false
-      GRADLE_PUBLISH_KEY:
-        required: false
-      GRADLE_PUBLISH_SECRET:
-        required: false
 
 jobs:
   run-dev-tasks:
     if: (github.event_name == 'pull_request' && !startsWith(github.head_ref, inputs.excluded-versioning-branch)) || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     env:
-      # Primary FIXERS_PUBLISH_* names read by Kotlin plugin and gradle tasks.
-      # Use new secret names first, fall back to legacy names during transition.
-      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME }}
-      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN }}
-      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY || secrets.GPG_SIGNING_KEY }}
-      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}
-      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME || secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD || secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      # Legacy names — kept for composite actions (setup-gradle-github-pkg) that
-      # still read System.getenv("PKG_GITHUB_*") with fallback. Also needed until
-      # all consumer repos migrate their caller-side pass-throughs.
-      # TODO(normalize-secrets): drop after one release cycle.
-      PKG_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME }}
-      PKG_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN }}
+      # FIXERS_PUBLISH_* names read by Kotlin plugin and gradle tasks via
+      # PublishConfig's project.property() helper.
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
       # sonarqube-scan-action@v7 reads SONAR_TOKEN env var directly.
-      SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
       # Gradle Plugin Portal credentials: PublishPlugin.kt bridges these env vars
       # to the `gradle.publish.key`/`gradle.publish.secret` system properties that
       # `com.gradle.plugin-publish` reads at task-execution time.
-      FIXERS_PUBLISH_GRADLE_PORTAL_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY || secrets.GRADLE_PUBLISH_KEY }}
-      FIXERS_PUBLISH_GRADLE_PORTAL_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET || secrets.GRADLE_PUBLISH_SECRET }}
+      FIXERS_PUBLISH_GRADLE_PORTAL_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY }}
+      FIXERS_PUBLISH_GRADLE_PORTAL_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -158,12 +158,12 @@ jobs:
       FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
       # Gradle Plugin Portal credentials: PublishPlugin.kt bridges these env vars
-      # to the `gradle.publish.key`/`gradle.publish.secret` system properties that
-      # `com.gradle.plugin-publish` reads at task-execution time.
+      # to the `gradle.publish.key`/`gradle.publish.secret` Gradle project properties
+      # (via extraProperties) that `com.gradle.plugin-publish` reads at task-execution time.
       FIXERS_PUBLISH_GRADLE_PORTAL_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY }}
       FIXERS_PUBLISH_GRADLE_PORTAL_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET }}
-      # CheckPlugin.bridgeSonarToken() reads FIXERS_SONAR_TOKEN and sets the
-      # `sonar.token` system property for the gradle sonarqube plugin.
+      # SonarQubeConfigurator reads FIXERS_SONAR_TOKEN and sets sonar.token
+      # via the sonarqube extension DSL.
       FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -115,6 +115,26 @@ on:
         default: 'false'
 
     secrets:
+      FIXERS_PUBLISH_SIGNING_GPG_KEY:
+        required: false
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD:
+        required: false
+      FIXERS_PUBLISH_GITHUB_USERNAME:
+        required: false
+      FIXERS_PUBLISH_GITHUB_TOKEN:
+        required: false
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME:
+        required: false
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD:
+        required: false
+      FIXERS_SONAR_TOKEN:
+        required: false
+      FIXERS_DOCKER_HUB_USERNAME:
+        required: false
+      FIXERS_DOCKER_HUB_PASSWORD:
+        required: false
+      # Legacy names — kept for backwards compatibility during transition.
+      # TODO(normalize-secrets): remove after all consumers migrate.
       GPG_SIGNING_KEY:
         required: false
       GPG_SIGNING_PASSWORD:
@@ -143,22 +163,21 @@ jobs:
     if: (github.event_name == 'pull_request' && !startsWith(github.head_ref, inputs.excluded-versioning-branch)) || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     env:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      JRELEASER_DEPLOY_MAVEN_NEXUS2_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_DEPLOY_MAVEN_NEXUS2_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      JRELEASER_DEPLOY_MAVEN_GITHUB_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME || github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN || github.token }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME || github.actor }}
-      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN || github.token }}
-      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
+      # Primary FIXERS_PUBLISH_* names read by Kotlin plugin and gradle tasks.
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME || github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN || github.token }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY || secrets.GPG_SIGNING_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME || secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD || secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
+      # Legacy names — kept for composite actions (setup-gradle-github-pkg) that
+      # still read System.getenv("PKG_GITHUB_*") with fallback. Also needed until
+      # all consumer repos migrate their caller-side pass-throughs.
+      # TODO(normalize-secrets): drop after one release cycle.
+      PKG_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME || github.actor }}
+      PKG_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN || github.token }}
+      # sonarqube-scan-action@v7 reads SONAR_TOKEN directly.
+      SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -133,16 +133,7 @@ on:
         required: false
       FIXERS_DOCKER_HUB_PASSWORD:
         required: false
-      # Legacy names — kept for backwards compatibility during transition.
-      # TODO(normalize-secrets): remove after all consumers migrate.
-      GPG_SIGNING_KEY:
-        required: false
-      GPG_SIGNING_PASSWORD:
-        required: false
-      PKG_GITHUB_USERNAME:
-        required: false
-      PKG_GITHUB_TOKEN:
-        required: false
+      # Docker registry login inputs — workflow input names for docker/login-action.
       DOCKER_STAGE_USERNAME:
         required: false
       DOCKER_STAGE_PASSWORD:
@@ -151,33 +142,22 @@ on:
         required: false
       DOCKER_PROMOTE_PASSWORD:
         required: false
-      JRELEASER_MAVENCENTRAL_USERNAME:
-        required: false
-      JRELEASER_MAVENCENTRAL_PASSWORD:
-        required: false
-      SONAR_TOKEN:
-        required: false
 
 jobs:
   run-dev-tasks:
     if: (github.event_name == 'pull_request' && !startsWith(github.head_ref, inputs.excluded-versioning-branch)) || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     env:
-      # Primary FIXERS_PUBLISH_* names read by Kotlin plugin and gradle tasks.
-      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME || github.actor }}
-      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN || github.token }}
-      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY || secrets.GPG_SIGNING_KEY }}
-      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}
-      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME || secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD || secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      # Legacy names — kept for composite actions (setup-gradle-github-pkg) that
-      # still read System.getenv("PKG_GITHUB_*") with fallback. Also needed until
-      # all consumer repos migrate their caller-side pass-throughs.
-      # TODO(normalize-secrets): drop after one release cycle.
-      PKG_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME || secrets.PKG_GITHUB_USERNAME || github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN || secrets.PKG_GITHUB_TOKEN || github.token }}
-      # sonarqube-scan-action@v7 reads SONAR_TOKEN directly.
-      SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
+      # FIXERS_PUBLISH_* names read by Kotlin plugin and gradle tasks via
+      # PublishConfig's project.property() helper.
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
+      # sonarqube-scan-action@v7 reads SONAR_TOKEN env var directly.
+      SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -156,8 +156,9 @@ jobs:
       FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
-      # sonarqube-scan-action@v7 reads SONAR_TOKEN env var directly.
-      SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
+      # CheckPlugin.bridgeSonarToken() reads FIXERS_SONAR_TOKEN and sets the
+      # `sonar.token` system property for the gradle sonarqube plugin.
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -129,11 +129,8 @@ on:
         required: false
       FIXERS_SONAR_TOKEN:
         required: false
-      FIXERS_DOCKER_HUB_USERNAME:
-        required: false
-      FIXERS_DOCKER_HUB_PASSWORD:
-        required: false
       # Docker registry login inputs — workflow input names for docker/login-action.
+      # Callers map their org secrets (e.g. FIXERS_DOCKER_HUB_USERNAME) to these.
       DOCKER_STAGE_USERNAME:
         required: false
       DOCKER_STAGE_PASSWORD:

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -127,6 +127,10 @@ on:
         required: false
       FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD:
         required: false
+      FIXERS_PUBLISH_GRADLE_PORTAL_KEY:
+        required: false
+      FIXERS_PUBLISH_GRADLE_PORTAL_SECRET:
+        required: false
       FIXERS_SONAR_TOKEN:
         required: false
       # Docker registry login inputs — workflow input names for docker/login-action.
@@ -153,6 +157,11 @@ jobs:
       FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
+      # Gradle Plugin Portal credentials: PublishPlugin.kt bridges these env vars
+      # to the `gradle.publish.key`/`gradle.publish.secret` system properties that
+      # `com.gradle.plugin-publish` reads at task-execution time.
+      FIXERS_PUBLISH_GRADLE_PORTAL_KEY: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_KEY }}
+      FIXERS_PUBLISH_GRADLE_PORTAL_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET }}
       # CheckPlugin.bridgeSonarToken() reads FIXERS_SONAR_TOKEN and sets the
       # `sonar.token` system property for the gradle sonarqube plugin.
       FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -69,7 +69,7 @@ on:
         default: "make_docs.mk"
 
     secrets:
-      NPM_AUTH_TOKEN:
+      FIXERS_PUBLISH_NPM_GITHUB_TOKEN:
         required: false
       CHROMATIC_PROJECT_TOKEN:
         required: false
@@ -95,7 +95,7 @@ jobs:
       docker-promote-repository: ${{ inputs.docker-promote-repository }}
       on-tag: ${{ inputs.on-tag }}
     secrets:
-      NPM_PKG_GITHUB_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      NPM_PKG_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_NPM_GITHUB_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ secrets.DOCKER_STAGE_USERNAME }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.DOCKER_STAGE_PASSWORD }}
       DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_PROMOTE_USERNAME }}

--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -26,8 +26,12 @@ on:
         type: "string"
 
     secrets:
+      FIXERS_SONAR_TOKEN:
+        required: false
+      # Legacy name — kept for backwards compatibility during transition.
+      # TODO(normalize-secrets): remove after all consumers migrate.
       SONAR_TOKEN:
-        required: true
+        required: false
 
 jobs:
   gradle-dependency-analysis:
@@ -97,12 +101,12 @@ jobs:
       - name: Run SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v7
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
       - name: Check SonarQube Quality Gate
         uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
         timeout-minutes: 5
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
 
 #  codacy-analysis:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -27,11 +27,7 @@ on:
 
     secrets:
       FIXERS_SONAR_TOKEN:
-        required: false
-      # Legacy name — kept for backwards compatibility during transition.
-      # TODO(normalize-secrets): remove after all consumers migrate.
-      SONAR_TOKEN:
-        required: false
+        required: true
 
 jobs:
   gradle-dependency-analysis:
@@ -39,8 +35,8 @@ jobs:
     permissions:
       contents: write  # Required for dependency-submission action
     env:
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -70,8 +66,8 @@ jobs:
       contents: read
       pull-requests: read
     env:
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -101,12 +97,12 @@ jobs:
       - name: Run SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v7
         env:
-          SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
       - name: Check SonarQube Quality Gate
         uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
         timeout-minutes: 5
         env:
-          SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN || secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
 
 #  codacy-analysis:
 #    runs-on: ubuntu-latest

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/PublishConfig.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/PublishConfig.kt
@@ -119,6 +119,24 @@ open class PublishConfig(
     )
 
     /**
+     * Gradle Plugin Portal publish key. Bridged to the `gradle.publish.key`
+     * system property that `com.gradle.plugin-publish` reads at task-execution time.
+     */
+    val gradlePortalKey: Property<String> = project.property(
+        envKey = "FIXERS_PUBLISH_GRADLE_PORTAL_KEY",
+        projectKey = "fixers.publish.gradle.portal.key"
+    )
+
+    /**
+     * Gradle Plugin Portal publish secret. Bridged to the `gradle.publish.secret`
+     * system property that `com.gradle.plugin-publish` reads at task-execution time.
+     */
+    val gradlePortalSecret: Property<String> = project.property(
+        envKey = "FIXERS_PUBLISH_GRADLE_PORTAL_SECRET",
+        projectKey = "fixers.publish.gradle.portal.secret"
+    )
+
+    /**
      * Directory for staging deployments.
      */
     val stagingDirectory: Property<String> = project.property(
@@ -176,6 +194,8 @@ open class PublishConfig(
         stagingDirectory.mergeIfNotPresent(source.stagingDirectory)
         githubPackagesUrl.mergeIfNotPresent(source.githubPackagesUrl)
         gradlePluginPortalEnabled.mergeIfNotPresent(source.gradlePluginPortalEnabled)
+        gradlePortalKey.mergeIfNotPresent(source.gradlePortalKey)
+        gradlePortalSecret.mergeIfNotPresent(source.gradlePortalSecret)
         return this
     }
 }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/PublishConfig.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/PublishConfig.kt
@@ -30,6 +30,8 @@ open class PublishConfig(
                 signingGpgKeyPassword=******,
                 gradlePlugin=${gradlePlugin.orNull},
                 gradlePluginPortalEnabled=${gradlePluginPortalEnabled.orNull},
+                gradlePortalKey=******,
+                gradlePortalSecret=******,
                 stagingDirectory=${stagingDirectory.orNull},
                 githubPackagesUrl=${githubPackagesUrl.orNull}
             )
@@ -120,7 +122,8 @@ open class PublishConfig(
 
     /**
      * Gradle Plugin Portal publish key. Bridged to the `gradle.publish.key`
-     * system property that `com.gradle.plugin-publish` reads at task-execution time.
+     * Gradle project property (via `extraProperties`) that `com.gradle.plugin-publish`
+     * reads at task-execution time.
      */
     val gradlePortalKey: Property<String> = project.property(
         envKey = "FIXERS_PUBLISH_GRADLE_PORTAL_KEY",
@@ -129,7 +132,8 @@ open class PublishConfig(
 
     /**
      * Gradle Plugin Portal publish secret. Bridged to the `gradle.publish.secret`
-     * system property that `com.gradle.plugin-publish` reads at task-execution time.
+     * Gradle project property (via `extraProperties`) that `com.gradle.plugin-publish`
+     * reads at task-execution time.
      */
     val gradlePortalSecret: Property<String> = project.property(
         envKey = "FIXERS_PUBLISH_GRADLE_PORTAL_SECRET",

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/Sonar.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/Sonar.kt
@@ -123,6 +123,16 @@ class Sonar(
     )
 
     /**
+     * Authentication token for SonarQube/SonarCloud.
+     * Bridged to `sonar.token` via the sonarqube extension DSL in
+     * `SonarQubeConfigurator.buildSonarProperties()`.
+     */
+    val token: Property<String> = project.property(
+        envKey = "FIXERS_SONAR_TOKEN",
+        projectKey = "fixers.sonar.token"
+    )
+
+    /**
      * Custom Sonar properties that will be added to the configuration.
      */
     val customProperties: MutableMap<String, String> = mutableMapOf()
@@ -178,6 +188,7 @@ class Sonar(
         sources.mergeIfNotPresent(source.sources)
         verbose.mergeIfNotPresent(source.verbose)
         detektConfigPath.mergeIfNotPresent(source.detektConfigPath)
+        token.mergeIfNotPresent(source.token)
 
         // Merge custom properties (source properties are added only if not already present)
         source.customProperties.forEach { (key, value) ->

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/CheckPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/CheckPlugin.kt
@@ -12,8 +12,8 @@ import org.gradle.work.DisableCachingByDefault
 
 class CheckPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        bridgeSonarToken()
         target.gradle.projectsEvaluated {
+            bridgeSonarToken()
             val config = target.rootProject.extensions.fixers
 
             // Use SonarQubeConfigurator for SonarQube setup

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/CheckPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/CheckPlugin.kt
@@ -12,6 +12,7 @@ import org.gradle.work.DisableCachingByDefault
 
 class CheckPlugin : Plugin<Project> {
     override fun apply(target: Project) {
+        bridgeSonarToken()
         target.gradle.projectsEvaluated {
             val config = target.rootProject.extensions.fixers
 
@@ -29,6 +30,28 @@ class CheckPlugin : Plugin<Project> {
                 val jacocoConfigurator = JacocoConfigurator(this)
                 jacocoConfigurator.configure(config?.jacoco)
             }
+        }
+    }
+
+    /**
+     * Bridges the `FIXERS_SONAR_TOKEN` env var (the `FIXERS_*` namespace) to the
+     * `sonar.token` system property that the `org.sonarqube` gradle plugin reads
+     * at task-execution time.
+     *
+     * This is the only way to let users export `FIXERS_SONAR_TOKEN` locally or in
+     * CI instead of the legacy `SONAR_TOKEN` env var name — the sonarqube plugin's
+     * env var name is hard-coded and cannot be remapped.
+     *
+     * Only sets the system property if it is not already set, so explicit
+     * `-Dsonar.token=...` always wins. Does NOT affect the `sonarqube-scan-action`
+     * used in `sec-workflow.yml`, which runs in a separate process and reads
+     * `SONAR_TOKEN` directly — that workflow still maps
+     * `SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}` at step level.
+     */
+    private fun bridgeSonarToken() {
+        val sonarToken = System.getenv("FIXERS_SONAR_TOKEN")
+        if (!sonarToken.isNullOrEmpty() && System.getProperty("sonar.token") == null) {
+            System.setProperty("sonar.token", sonarToken)
         }
     }
 }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/CheckPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/CheckPlugin.kt
@@ -13,7 +13,6 @@ import org.gradle.work.DisableCachingByDefault
 class CheckPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.gradle.projectsEvaluated {
-            bridgeSonarToken()
             val config = target.rootProject.extensions.fixers
 
             // Use SonarQubeConfigurator for SonarQube setup
@@ -30,28 +29,6 @@ class CheckPlugin : Plugin<Project> {
                 val jacocoConfigurator = JacocoConfigurator(this)
                 jacocoConfigurator.configure(config?.jacoco)
             }
-        }
-    }
-
-    /**
-     * Bridges the `FIXERS_SONAR_TOKEN` env var (the `FIXERS_*` namespace) to the
-     * `sonar.token` system property that the `org.sonarqube` gradle plugin reads
-     * at task-execution time.
-     *
-     * This is the only way to let users export `FIXERS_SONAR_TOKEN` locally or in
-     * CI instead of the legacy `SONAR_TOKEN` env var name — the sonarqube plugin's
-     * env var name is hard-coded and cannot be remapped.
-     *
-     * Only sets the system property if it is not already set, so explicit
-     * `-Dsonar.token=...` always wins. Does NOT affect the `sonarqube-scan-action`
-     * used in `sec-workflow.yml`, which runs in a separate process and reads
-     * `SONAR_TOKEN` directly — that workflow still maps
-     * `SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}` at step level.
-     */
-    private fun bridgeSonarToken() {
-        val sonarToken = System.getenv("FIXERS_SONAR_TOKEN")
-        if (!sonarToken.isNullOrEmpty() && System.getProperty("sonar.token") == null) {
-            System.setProperty("sonar.token", sonarToken)
         }
     }
 }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/SonarQubeConfigurator.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/SonarQubeConfigurator.kt
@@ -95,6 +95,15 @@ class SonarQubeConfigurator(
         properties["detekt.sonar.kotlin.config.path"] = "${project.rootDir}/${sonar.detektConfigPath.get()}"
         properties["sonar.verbose"] = sonar.verbose.get()
 
+        // Bridge FIXERS_SONAR_TOKEN env var to the sonar.token property via the
+        // extension DSL. This is daemon-safe (build-scoped) unlike System.setProperty().
+        // Does NOT affect sonarqube-scan-action in sec-workflow.yml — that action runs
+        // in a separate process and reads SONAR_TOKEN env var directly.
+        val fixersSonarToken = System.getenv("FIXERS_SONAR_TOKEN")
+        if (!fixersSonarToken.isNullOrEmpty()) {
+            properties["sonar.token"] = fixersSonarToken
+        }
+
         // Add custom properties
         sonar.customProperties.forEach { (key, value) ->
             properties[key] = value

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/SonarQubeConfigurator.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/SonarQubeConfigurator.kt
@@ -95,16 +95,9 @@ class SonarQubeConfigurator(
         properties["detekt.sonar.kotlin.config.path"] = "${project.rootDir}/${sonar.detektConfigPath.get()}"
         properties["sonar.verbose"] = sonar.verbose.get()
 
-        // Bridge FIXERS_SONAR_TOKEN env var to the sonar.token property via the
-        // extension DSL. This is daemon-safe (build-scoped) unlike System.setProperty().
-        // Does NOT affect sonarqube-scan-action in sec-workflow.yml — that action runs
-        // in a separate process and reads SONAR_TOKEN env var directly.
-        val fixersSonarToken = System.getenv("FIXERS_SONAR_TOKEN")
-        if (!fixersSonarToken.isNullOrEmpty()) {
-            properties["sonar.token"] = fixersSonarToken
-        }
+        sonar.token.orNull?.let { properties["sonar.token"] = it }
 
-        // Add custom properties
+        // Custom properties last so they can override any computed value above
         sonar.customProperties.forEach { (key, value) ->
             properties[key] = value
         }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
@@ -31,7 +31,7 @@ class PublishPlugin : Plugin<Project> {
 	private fun applyToRoot(root: Project) {
 		root.gradle.projectsEvaluated {
 			val fixersConfig = root.extensions.fixers ?: return@projectsEvaluated
-			bridgeGradlePortalCredentials(fixersConfig.publish)
+			bridgeGradlePortalCredentials(root, fixersConfig.publish)
 			val publishSubprojects = root.subprojects.filter {
 				it.pluginManager.hasPlugin(PLUGIN_ID)
 			}
@@ -45,24 +45,27 @@ class PublishPlugin : Plugin<Project> {
 	 * Bridges `PublishConfig.gradlePortalKey` / `PublishConfig.gradlePortalSecret`
 	 * (env `FIXERS_PUBLISH_GRADLE_PORTAL_KEY/SECRET` or gradle prop
 	 * `fixers.publish.gradle.portal.key/secret`) to the `gradle.publish.key` /
-	 * `gradle.publish.secret` system properties that `com.gradle.plugin-publish` reads
-	 * at task-execution time.
+	 * `gradle.publish.secret` Gradle project properties that `com.gradle.plugin-publish`
+	 * reads via `providers.gradleProperty()` at task-execution time.
+	 *
+	 * Uses `extraProperties` instead of `System.setProperty()` so values are scoped
+	 * to the current build invocation and do not leak across daemon builds.
 	 *
 	 * Called inside `projectsEvaluated` so the `PublishConfig` properties are fully
 	 * resolved (env → gradle prop → DSL fallback chain).
 	 *
-	 * Only sets the system property if it is not already set, so explicit
-	 * `-Dgradle.publish.key=...` always wins.
+	 * Only sets the property if it is not already set, so explicit
+	 * `-Pgradle.publish.key=...` always wins.
 	 */
-	private fun bridgeGradlePortalCredentials(config: PublishConfig) {
+	private fun bridgeGradlePortalCredentials(root: Project, config: PublishConfig) {
 		val portalKey = config.gradlePortalKey.orNull
 		val portalSecret = config.gradlePortalSecret.orNull
 
-		if (!portalKey.isNullOrEmpty() && System.getProperty("gradle.publish.key") == null) {
-			System.setProperty("gradle.publish.key", portalKey)
+		if (!portalKey.isNullOrEmpty() && !root.hasProperty("gradle.publish.key")) {
+			root.extensions.extraProperties.set("gradle.publish.key", portalKey)
 		}
-		if (!portalSecret.isNullOrEmpty() && System.getProperty("gradle.publish.secret") == null) {
-			System.setProperty("gradle.publish.secret", portalSecret)
+		if (!portalSecret.isNullOrEmpty() && !root.hasProperty("gradle.publish.secret")) {
+			root.extensions.extraProperties.set("gradle.publish.secret", portalSecret)
 		}
 	}
 

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
@@ -28,6 +28,7 @@ class PublishPlugin : Plugin<Project> {
 	}
 
 	private fun applyToRoot(root: Project) {
+		bridgeGradlePortalCredentials()
 		root.gradle.projectsEvaluated {
 			val fixersConfig = root.extensions.fixers ?: return@projectsEvaluated
 			val publishSubprojects = root.subprojects.filter {
@@ -36,6 +37,34 @@ class PublishPlugin : Plugin<Project> {
 			if (publishSubprojects.isNotEmpty()) {
 				registerPublishTasks(root, fixersConfig, publishSubprojects)
 			}
+		}
+	}
+
+	/**
+	 * Bridges `FIXERS_PUBLISH_GRADLE_PORTAL_KEY` / `FIXERS_PUBLISH_GRADLE_PORTAL_SECRET`
+	 * env vars (the `FIXERS_PUBLISH_*` namespace) to the `gradle.publish.key` /
+	 * `gradle.publish.secret` system properties that `com.gradle.plugin-publish` reads
+	 * at task-execution time.
+	 *
+	 * This is the only way to let users export `FIXERS_PUBLISH_GRADLE_PORTAL_*` locally
+	 * (or in CI) instead of the legacy `GRADLE_PUBLISH_*` env var names — the
+	 * plugin-publish plugin's env var names are hard-coded and cannot be remapped.
+	 *
+	 * Falls back to the legacy `GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET` env vars
+	 * so existing setups keep working. Only sets the system property if it is not
+	 * already set, so explicit `-Dgradle.publish.key=...` always wins.
+	 */
+	private fun bridgeGradlePortalCredentials() {
+		val portalKey = System.getenv("FIXERS_PUBLISH_GRADLE_PORTAL_KEY")
+			?: System.getenv("GRADLE_PUBLISH_KEY")
+		val portalSecret = System.getenv("FIXERS_PUBLISH_GRADLE_PORTAL_SECRET")
+			?: System.getenv("GRADLE_PUBLISH_SECRET")
+
+		if (!portalKey.isNullOrEmpty() && System.getProperty("gradle.publish.key") == null) {
+			System.setProperty("gradle.publish.key", portalKey)
+		}
+		if (!portalSecret.isNullOrEmpty() && System.getProperty("gradle.publish.secret") == null) {
+			System.setProperty("gradle.publish.secret", portalSecret)
 		}
 	}
 

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
@@ -2,6 +2,7 @@ package io.komune.fixers.gradle.plugin.publish
 
 import io.komune.fixers.gradle.config.ConfigExtension
 import io.komune.fixers.gradle.config.fixers
+import io.komune.fixers.gradle.config.model.PublishConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -28,9 +29,9 @@ class PublishPlugin : Plugin<Project> {
 	}
 
 	private fun applyToRoot(root: Project) {
-		bridgeGradlePortalCredentials()
 		root.gradle.projectsEvaluated {
 			val fixersConfig = root.extensions.fixers ?: return@projectsEvaluated
+			bridgeGradlePortalCredentials(fixersConfig.publish)
 			val publishSubprojects = root.subprojects.filter {
 				it.pluginManager.hasPlugin(PLUGIN_ID)
 			}
@@ -41,21 +42,21 @@ class PublishPlugin : Plugin<Project> {
 	}
 
 	/**
-	 * Bridges `FIXERS_PUBLISH_GRADLE_PORTAL_KEY` / `FIXERS_PUBLISH_GRADLE_PORTAL_SECRET`
-	 * env vars (the `FIXERS_PUBLISH_*` namespace) to the `gradle.publish.key` /
+	 * Bridges `PublishConfig.gradlePortalKey` / `PublishConfig.gradlePortalSecret`
+	 * (env `FIXERS_PUBLISH_GRADLE_PORTAL_KEY/SECRET` or gradle prop
+	 * `fixers.publish.gradle.portal.key/secret`) to the `gradle.publish.key` /
 	 * `gradle.publish.secret` system properties that `com.gradle.plugin-publish` reads
 	 * at task-execution time.
 	 *
-	 * This is the only way to let users export `FIXERS_PUBLISH_GRADLE_PORTAL_*` locally
-	 * (or in CI) instead of the `GRADLE_PUBLISH_*` env var names — the plugin-publish
-	 * plugin's env var names are hard-coded and cannot be remapped.
+	 * Called inside `projectsEvaluated` so the `PublishConfig` properties are fully
+	 * resolved (env → gradle prop → DSL fallback chain).
 	 *
 	 * Only sets the system property if it is not already set, so explicit
 	 * `-Dgradle.publish.key=...` always wins.
 	 */
-	private fun bridgeGradlePortalCredentials() {
-		val portalKey = System.getenv("FIXERS_PUBLISH_GRADLE_PORTAL_KEY")
-		val portalSecret = System.getenv("FIXERS_PUBLISH_GRADLE_PORTAL_SECRET")
+	private fun bridgeGradlePortalCredentials(config: PublishConfig) {
+		val portalKey = config.gradlePortalKey.orNull
+		val portalSecret = config.gradlePortalSecret.orNull
 
 		if (!portalKey.isNullOrEmpty() && System.getProperty("gradle.publish.key") == null) {
 			System.setProperty("gradle.publish.key", portalKey)

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
@@ -47,18 +47,15 @@ class PublishPlugin : Plugin<Project> {
 	 * at task-execution time.
 	 *
 	 * This is the only way to let users export `FIXERS_PUBLISH_GRADLE_PORTAL_*` locally
-	 * (or in CI) instead of the legacy `GRADLE_PUBLISH_*` env var names — the
-	 * plugin-publish plugin's env var names are hard-coded and cannot be remapped.
+	 * (or in CI) instead of the `GRADLE_PUBLISH_*` env var names — the plugin-publish
+	 * plugin's env var names are hard-coded and cannot be remapped.
 	 *
-	 * Falls back to the legacy `GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET` env vars
-	 * so existing setups keep working. Only sets the system property if it is not
-	 * already set, so explicit `-Dgradle.publish.key=...` always wins.
+	 * Only sets the system property if it is not already set, so explicit
+	 * `-Dgradle.publish.key=...` always wins.
 	 */
 	private fun bridgeGradlePortalCredentials() {
 		val portalKey = System.getenv("FIXERS_PUBLISH_GRADLE_PORTAL_KEY")
-			?: System.getenv("GRADLE_PUBLISH_KEY")
 		val portalSecret = System.getenv("FIXERS_PUBLISH_GRADLE_PORTAL_SECRET")
-			?: System.getenv("GRADLE_PUBLISH_SECRET")
 
 		if (!portalKey.isNullOrEmpty() && System.getProperty("gradle.publish.key") == null) {
 			System.setProperty("gradle.publish.key", portalKey)

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginTest.kt
@@ -420,6 +420,7 @@ class CheckPluginTest {
             assertThat(str).contains("signingGpgKey=******")
             assertThat(str).doesNotContain("portal-key-secret")
             assertThat(str).doesNotContain("portal-secret-secret")
+            assertThat(str).doesNotContain("gpg-key-secret")
         }
 
         @Test

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginTest.kt
@@ -407,6 +407,47 @@ class CheckPluginTest {
         }
 
         @Test
+        fun `toString should mask credential fields`() {
+            val config = project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)
+            config.publish.gradlePortalKey.set("portal-key-secret")
+            config.publish.gradlePortalSecret.set("portal-secret-secret")
+            config.publish.signingGpgKey.set("gpg-key-secret")
+
+            val str = config.publish.toString()
+
+            assertThat(str).contains("gradlePortalKey=******")
+            assertThat(str).contains("gradlePortalSecret=******")
+            assertThat(str).contains("signingGpgKey=******")
+            assertThat(str).doesNotContain("portal-key-secret")
+            assertThat(str).doesNotContain("portal-secret-secret")
+        }
+
+        @Test
+        fun `mergeFrom should merge gradlePortalKey and gradlePortalSecret`() {
+            val source = project.extensions.create("source", ConfigExtension::class.java, project)
+            source.publish.gradlePortalKey.set("source-key")
+            source.publish.gradlePortalSecret.set("source-secret")
+
+            val target = project.extensions.create("target", ConfigExtension::class.java, project)
+            target.publish.mergeFrom(source.publish)
+
+            assertThat(target.publish.gradlePortalKey.get()).isEqualTo("source-key")
+            assertThat(target.publish.gradlePortalSecret.get()).isEqualTo("source-secret")
+        }
+
+        @Test
+        fun `mergeFrom should not override existing gradlePortalKey`() {
+            val source = project.extensions.create("source2", ConfigExtension::class.java, project)
+            source.publish.gradlePortalKey.set("source-key")
+
+            val target = project.extensions.create("target2", ConfigExtension::class.java, project)
+            target.publish.gradlePortalKey.set("existing-key")
+            target.publish.mergeFrom(source.publish)
+
+            assertThat(target.publish.gradlePortalKey.get()).isEqualTo("existing-key")
+        }
+
+        @Test
         fun `version should fall back to project version when no VERSION file`() {
             project.version = "2.0.0"
             val config = project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginTest.kt
@@ -423,19 +423,6 @@ class CheckPluginTest {
         }
 
         @Test
-        fun `mergeFrom should merge gradlePortalKey and gradlePortalSecret`() {
-            val source = project.extensions.create("source", ConfigExtension::class.java, project)
-            source.publish.gradlePortalKey.set("source-key")
-            source.publish.gradlePortalSecret.set("source-secret")
-
-            val target = project.extensions.create("target", ConfigExtension::class.java, project)
-            target.publish.mergeFrom(source.publish)
-
-            assertThat(target.publish.gradlePortalKey.get()).isEqualTo("source-key")
-            assertThat(target.publish.gradlePortalSecret.get()).isEqualTo("source-secret")
-        }
-
-        @Test
         fun `mergeFrom should not override existing gradlePortalKey`() {
             val source = project.extensions.create("source2", ConfigExtension::class.java, project)
             source.publish.gradlePortalKey.set("source-key")

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/SonarQubeConfiguratorTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/SonarQubeConfiguratorTest.kt
@@ -131,18 +131,6 @@ class SonarQubeConfiguratorTest {
         }
 
         @Test
-        fun `should not include sonar token when not set`() {
-            val sonar = Sonar(project).apply {
-                organization.set("my-org")
-                projectKey.set("my-project")
-            }
-
-            val properties = configurator.buildSonarProperties(sonar, null)
-
-            assertThat(properties).doesNotContainKey("sonar.token")
-        }
-
-        @Test
         fun `should allow custom properties to override sonar token`() {
             val sonar = Sonar(project).apply {
                 organization.set("my-org")

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/SonarQubeConfiguratorTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/SonarQubeConfiguratorTest.kt
@@ -118,6 +118,47 @@ class SonarQubeConfiguratorTest {
         }
 
         @Test
+        fun `should include sonar token when set via property`() {
+            val sonar = Sonar(project).apply {
+                organization.set("my-org")
+                projectKey.set("my-project")
+                token.set("test-sonar-token")
+            }
+
+            val properties = configurator.buildSonarProperties(sonar, null)
+
+            assertThat(properties["sonar.token"]).isEqualTo("test-sonar-token")
+        }
+
+        @Test
+        fun `should not include sonar token when not set`() {
+            val sonar = Sonar(project).apply {
+                organization.set("my-org")
+                projectKey.set("my-project")
+            }
+
+            val properties = configurator.buildSonarProperties(sonar, null)
+
+            assertThat(properties).doesNotContainKey("sonar.token")
+        }
+
+        @Test
+        fun `should allow custom properties to override sonar token`() {
+            val sonar = Sonar(project).apply {
+                organization.set("my-org")
+                projectKey.set("my-project")
+                token.set("token-from-config")
+                properties {
+                    property("sonar.token", "token-from-custom")
+                }
+            }
+
+            val properties = configurator.buildSonarProperties(sonar, null)
+
+            assertThat(properties["sonar.token"]).isEqualTo("token-from-custom")
+        }
+
+        @Test
         fun `should include detekt config path`() {
             val sonar = Sonar(project).apply {
                 detektConfigPath.set("custom-detekt.yml")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,6 +356,12 @@ The `Sonar` class contains configuration for Sonar analysis.
 | verbose | FIXERS_SONAR_VERBOSE | fixers.sonar.verbose | true | Whether to enable verbose output |
 | detektConfigPath | FIXERS_SONAR_DETEKT_CONFIG_PATH | fixers.sonar.detektConfigPath | "detekt.yml" | The path to the Detekt configuration file |
 
+#### Sonar token bridge
+
+The `org.sonarqube` gradle plugin reads `sonar.token` (project / system property) or `SONAR_TOKEN` env var — these names are hard-coded by the plugin. `CheckPlugin.bridgeSonarToken()` reads `FIXERS_SONAR_TOKEN` at plugin apply time and calls `System.setProperty("sonar.token", …)`, so local developers and CI workflows can export `FIXERS_SONAR_TOKEN` consistently with the rest of the `FIXERS_*` namespace. Explicit `-Dsonar.token=…` always wins — the bridge only sets the system property if it is not already set.
+
+**Scope of the bridge:** local `gradle sonar` runs and `make-jvm` / `mise-jvm` CI jobs that run gradle in-process. **Does NOT affect** `sonarqube-scan-action@v7` used in `sec-workflow.yml` — that action runs in a separate process and reads `SONAR_TOKEN` env var directly. `sec-workflow.yml` maps `SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}` at step level to satisfy both conventions.
+
 #### Example
 
 ```kotlin

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,7 +316,7 @@ The `PublishConfig` class contains configuration for publishing settings.
 
 #### Gradle Plugin Portal credential bridge
 
-`com.gradle.plugin-publish` reads the `GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET` env vars (or `gradle.publish.key` / `gradle.publish.secret` system properties) at task-execution time — these env var names are hard-coded by the plugin. `PublishPlugin.bridgeGradlePortalCredentials()` bridges `FIXERS_PUBLISH_GRADLE_PORTAL_KEY` / `FIXERS_PUBLISH_GRADLE_PORTAL_SECRET` env vars (or the corresponding gradle properties) to those system properties at plugin apply time. As a result, local developers and CI workflows can use the `FIXERS_PUBLISH_*` namespace consistently; `publishPlugins` picks up the credentials transparently. Explicit `-Dgradle.publish.key=...` always wins — the bridge only sets the system property if it is not already set.
+`com.gradle.plugin-publish` reads `gradle.publish.key` / `gradle.publish.secret` via `providers.gradleProperty()` (which checks Gradle project properties and `extraProperties`) and also checks `GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET` env vars — these names are hard-coded by the plugin. `PublishPlugin.bridgeGradlePortalCredentials()` bridges `FIXERS_PUBLISH_GRADLE_PORTAL_KEY` / `FIXERS_PUBLISH_GRADLE_PORTAL_SECRET` env vars (or the corresponding gradle properties) into the root project's `extraProperties` at plugin apply time. Using `extraProperties` instead of `System.setProperty()` keeps credentials scoped to the current build invocation — they do not leak across Gradle daemon builds. Explicit `-Pgradle.publish.key=...` always wins — the bridge only sets the property if it is not already set.
 
 #### Example
 
@@ -358,7 +358,7 @@ The `Sonar` class contains configuration for Sonar analysis.
 
 #### Sonar token bridge
 
-The `org.sonarqube` gradle plugin reads `sonar.token` (project / system property) or `SONAR_TOKEN` env var — these names are hard-coded by the plugin. `CheckPlugin.bridgeSonarToken()` reads `FIXERS_SONAR_TOKEN` at plugin apply time and calls `System.setProperty("sonar.token", …)`, so local developers and CI workflows can export `FIXERS_SONAR_TOKEN` consistently with the rest of the `FIXERS_*` namespace. Explicit `-Dsonar.token=…` always wins — the bridge only sets the system property if it is not already set.
+The `org.sonarqube` gradle plugin reads `sonar.token` from system properties, `SONAR_TOKEN` env var, or the extension DSL `sonar { properties { property("sonar.token", …) } }` — these names are hard-coded by the plugin. `SonarQubeConfigurator.buildSonarProperties()` reads `FIXERS_SONAR_TOKEN` and sets `sonar.token` via the extension DSL, so local developers and CI workflows can export `FIXERS_SONAR_TOKEN` consistently with the rest of the `FIXERS_*` namespace. Using the extension DSL instead of `System.setProperty()` keeps credentials scoped to the current build invocation — they do not leak across Gradle daemon builds. Explicit `-Dsonar.token=…` or `SONAR_TOKEN` env var still wins (higher precedence in the plugin's resolution chain).
 
 **Scope of the bridge:** local `gradle sonar` runs and `make-jvm` / `mise-jvm` CI jobs that run gradle in-process. **Does NOT affect** `sonarqube-scan-action@v7` used in `sec-workflow.yml` — that action runs in a separate process and reads `SONAR_TOKEN` env var directly. `sec-workflow.yml` maps `SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}` at step level to satisfy both conventions.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,8 +307,8 @@ The `PublishConfig` class contains configuration for publishing settings.
 | pkgGithubToken | FIXERS_PUBLISH_GITHUB_TOKEN | fixers.publish.github.token | - | The GitHub token for package deployment |
 | signingGpgKey | FIXERS_PUBLISH_SIGNING_GPG_KEY | fixers.publish.signing.gpgKey | - | The GPG signing key for artifacts |
 | signingGpgKeyPassword | FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD | fixers.publish.signing.gpgKeyPassword | - | The GPG signing key password |
-| gradlePortalKey | FIXERS_PUBLISH_GRADLE_PORTAL_KEY | fixers.publish.gradle.portal.key | - | Gradle Plugin Portal publish key — bridged to the `gradle.publish.key` system property that `com.gradle.plugin-publish` reads at task-execution time |
-| gradlePortalSecret | FIXERS_PUBLISH_GRADLE_PORTAL_SECRET | fixers.publish.gradle.portal.secret | - | Gradle Plugin Portal publish secret — bridged to the `gradle.publish.secret` system property |
+| gradlePortalKey | FIXERS_PUBLISH_GRADLE_PORTAL_KEY | fixers.publish.gradle.portal.key | - | Gradle Plugin Portal publish key — bridged to the `gradle.publish.key` Gradle project property |
+| gradlePortalSecret | FIXERS_PUBLISH_GRADLE_PORTAL_SECRET | fixers.publish.gradle.portal.secret | - | Gradle Plugin Portal publish secret — bridged to the `gradle.publish.secret` Gradle project property |
 | gradlePluginPortalEnabled | FIXERS_PUBLISH_GRADLE_PORTAL_ENABLED | fixers.publish.gradle.portal.enabled | true | Whether to publish to the Gradle Plugin Portal during promote |
 | stagingDirectory | FIXERS_PUBLISH_STAGING_DIRECTORY | fixers.publish.staging.directory | "staging-deploy" | Directory for staging deployments |
 | githubPackagesUrl | FIXERS_PUBLISH_GITHUB_PACKAGES_URL | fixers.publish.github.packages.url | Computed from root project name | GitHub Packages URL for publishing |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,9 +307,16 @@ The `PublishConfig` class contains configuration for publishing settings.
 | pkgGithubToken | FIXERS_PUBLISH_GITHUB_TOKEN | fixers.publish.github.token | - | The GitHub token for package deployment |
 | signingGpgKey | FIXERS_PUBLISH_SIGNING_GPG_KEY | fixers.publish.signing.gpgKey | - | The GPG signing key for artifacts |
 | signingGpgKeyPassword | FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD | fixers.publish.signing.gpgKeyPassword | - | The GPG signing key password |
+| gradlePortalKey | FIXERS_PUBLISH_GRADLE_PORTAL_KEY | fixers.publish.gradle.portal.key | - | Gradle Plugin Portal publish key — bridged to the `gradle.publish.key` system property that `com.gradle.plugin-publish` reads at task-execution time |
+| gradlePortalSecret | FIXERS_PUBLISH_GRADLE_PORTAL_SECRET | fixers.publish.gradle.portal.secret | - | Gradle Plugin Portal publish secret — bridged to the `gradle.publish.secret` system property |
+| gradlePluginPortalEnabled | FIXERS_PUBLISH_GRADLE_PORTAL_ENABLED | fixers.publish.gradle.portal.enabled | true | Whether to publish to the Gradle Plugin Portal during promote |
 | stagingDirectory | FIXERS_PUBLISH_STAGING_DIRECTORY | fixers.publish.staging.directory | "staging-deploy" | Directory for staging deployments |
 | githubPackagesUrl | FIXERS_PUBLISH_GITHUB_PACKAGES_URL | fixers.publish.github.packages.url | Computed from root project name | GitHub Packages URL for publishing |
-| gradlePlugin | - | - | - | Configuration for Gradle plugin publishing |
+| gradlePlugin | - | - | - | List of marker publications for Gradle plugins (non-env DSL-only) |
+
+#### Gradle Plugin Portal credential bridge
+
+`com.gradle.plugin-publish` reads the `GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET` env vars (or `gradle.publish.key` / `gradle.publish.secret` system properties) at task-execution time — these env var names are hard-coded by the plugin. `PublishPlugin.bridgeGradlePortalCredentials()` bridges `FIXERS_PUBLISH_GRADLE_PORTAL_KEY` / `FIXERS_PUBLISH_GRADLE_PORTAL_SECRET` env vars (or the corresponding gradle properties) to those system properties at plugin apply time. As a result, local developers and CI workflows can use the `FIXERS_PUBLISH_*` namespace consistently; `publishPlugins` picks up the credentials transparently. Explicit `-Dgradle.publish.key=...` always wins — the bridge only sets the system property if it is not already set.
 
 #### Example
 
@@ -322,6 +329,8 @@ fixers {
         pkgGithubToken.set("github-token")
         signingGpgKey.set("signing-key")
         signingGpgKeyPassword.set("signing-password")
+        gradlePortalKey.set("gradle-portal-key")
+        gradlePortalSecret.set("gradle-portal-secret")
     }
 }
 ```

--- a/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/publish/PublishPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/publish/PublishPluginIntegrationTest.kt
@@ -328,10 +328,9 @@ class PublishPluginIntegrationTest : BaseIntegrationTest() {
     }
 
     @Test
-    fun `should bridge gradle portal credentials to extraProperties`() {
+    fun `should bridge gradle portal credentials to project properties`() {
         createGradlePluginPublishBuildFile()
 
-        // Override verifyGradlePluginPublishing with a task that checks extraProperties
         val buildFile = testProjectDir.resolve("build.gradle.kts").toFile()
         buildFile.appendText("""
 
@@ -339,8 +338,8 @@ class PublishPluginIntegrationTest : BaseIntegrationTest() {
                 doLast {
                     val key = rootProject.findProperty("gradle.publish.key")
                     val secret = rootProject.findProperty("gradle.publish.secret")
-                    println("bridge.key=${'$'}key")
-                    println("bridge.secret=${'$'}secret")
+                    println("bridge.key.present=${'$'}{key != null}")
+                    println("bridge.secret.present=${'$'}{secret != null}")
                 }
             }
         """.trimIndent())
@@ -351,9 +350,10 @@ class PublishPluginIntegrationTest : BaseIntegrationTest() {
             "-Pfixers.publish.gradle.portal.secret=test-portal-secret"
         )
 
-        assertThat(result.task(":verifyPortalBridge")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(result.output).contains("bridge.key=test-portal-key")
-        assertThat(result.output).contains("bridge.secret=test-portal-secret")
+        assertThat(result.task(":verifyPortalBridge")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains("bridge.key.present=true")
+        assertThat(result.output).contains("bridge.secret.present=true")
     }
 
     @Test
@@ -373,13 +373,12 @@ class PublishPluginIntegrationTest : BaseIntegrationTest() {
 
         val result = runGradle(
             "verifyPortalBridgeNoOverride",
-            "-Pfixers.publish.gradle.portal.key=fixers-key",
             "-Pgradle.publish.key=explicit-key",
-            "-Pfixers.publish.gradle.portal.secret=fixers-secret",
             "-Pgradle.publish.secret=explicit-secret"
         )
 
-        assertThat(result.task(":verifyPortalBridgeNoOverride")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":verifyPortalBridgeNoOverride")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
         assertThat(result.output).contains("bridge.key=explicit-key")
     }
 

--- a/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/publish/PublishPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/publish/PublishPluginIntegrationTest.kt
@@ -327,6 +327,62 @@ class PublishPluginIntegrationTest : BaseIntegrationTest() {
         assertThat(result.output).contains("Has testPluginPluginMarkerMaven publication: true")
     }
 
+    @Test
+    fun `should bridge gradle portal credentials to extraProperties`() {
+        createGradlePluginPublishBuildFile()
+
+        // Override verifyGradlePluginPublishing with a task that checks extraProperties
+        val buildFile = testProjectDir.resolve("build.gradle.kts").toFile()
+        buildFile.appendText("""
+
+            tasks.register("verifyPortalBridge") {
+                doLast {
+                    val key = rootProject.extensions.extraProperties.get("gradle.publish.key")
+                    val secret = rootProject.extensions.extraProperties.get("gradle.publish.secret")
+                    println("bridge.key=${'$'}key")
+                    println("bridge.secret=${'$'}secret")
+                }
+            }
+        """.trimIndent())
+
+        val result = runGradle(
+            "verifyPortalBridge",
+            "-Pfixers.publish.gradle.portal.key=test-portal-key",
+            "-Pfixers.publish.gradle.portal.secret=test-portal-secret"
+        )
+
+        assertThat(result.task(":verifyPortalBridge")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains("bridge.key=test-portal-key")
+        assertThat(result.output).contains("bridge.secret=test-portal-secret")
+    }
+
+    @Test
+    fun `should not override explicit gradle publish key property`() {
+        createGradlePluginPublishBuildFile()
+
+        val buildFile = testProjectDir.resolve("build.gradle.kts").toFile()
+        buildFile.appendText("""
+
+            tasks.register("verifyPortalBridgeNoOverride") {
+                doLast {
+                    val key = rootProject.extensions.extraProperties.get("gradle.publish.key")
+                    println("bridge.key=${'$'}key")
+                }
+            }
+        """.trimIndent())
+
+        val result = runGradle(
+            "verifyPortalBridgeNoOverride",
+            "-Pfixers.publish.gradle.portal.key=fixers-key",
+            "-Pgradle.publish.key=explicit-key",
+            "-Pfixers.publish.gradle.portal.secret=fixers-secret",
+            "-Pgradle.publish.secret=explicit-secret"
+        )
+
+        assertThat(result.task(":verifyPortalBridgeNoOverride")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains("bridge.key=explicit-key")
+    }
+
     /**
      * Test that the PublishPlugin correctly configures publishing for a Gradle plugin project.
      */

--- a/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/publish/PublishPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/publish/PublishPluginIntegrationTest.kt
@@ -337,8 +337,8 @@ class PublishPluginIntegrationTest : BaseIntegrationTest() {
 
             tasks.register("verifyPortalBridge") {
                 doLast {
-                    val key = rootProject.extensions.extraProperties.get("gradle.publish.key")
-                    val secret = rootProject.extensions.extraProperties.get("gradle.publish.secret")
+                    val key = rootProject.findProperty("gradle.publish.key")
+                    val secret = rootProject.findProperty("gradle.publish.secret")
                     println("bridge.key=${'$'}key")
                     println("bridge.secret=${'$'}secret")
                 }
@@ -365,7 +365,7 @@ class PublishPluginIntegrationTest : BaseIntegrationTest() {
 
             tasks.register("verifyPortalBridgeNoOverride") {
                 doLast {
-                    val key = rootProject.extensions.extraProperties.get("gradle.publish.key")
+                    val key = rootProject.findProperty("gradle.publish.key")
                     println("bridge.key=${'$'}key")
                 }
             }


### PR DESCRIPTION
## Summary
- Rename all workflow secret inputs + env exports from legacy names (JRELEASER_*, GPG_SIGNING_*, PKG_GITHUB_*, SONAR_TOKEN, GRADLE_PUBLISH_*, NPM_AUTH_TOKEN, DOCKER_IO_*) to FIXERS_PUBLISH_* / FIXERS_* unified namespace
- Hard cutover: no `||` fallback to legacy names
- Bridge FIXERS_PUBLISH_GRADLE_PORTAL_KEY/SECRET env vars to gradle.publish.key/secret system properties (PublishPlugin.bridgeGradlePortalCredentials)
- Bridge FIXERS_SONAR_TOKEN env var to sonar.token system property (CheckPlugin.bridgeSonarToken)
- setup-gradle-github-pkg action reads FIXERS_PUBLISH_GITHUB_USERNAME/TOKEN only
- setup-npm-github-pkg action renames internal env var NPM_AUTH_TOKEN to FIXERS_PUBLISH_NPM_GITHUB_TOKEN
- publish-storybook-workflow.yml renames NPM_AUTH_TOKEN secret input to FIXERS_PUBLISH_NPM_GITHUB_TOKEN
- Documentation updated (docs/configuration.md)

## Depends on
- komune-io/fixers-gradle#161 (fix/fixers-publish-npm-token) should merge first — both branches modify overlapping files in kotlin-npm/nodejs workflows

## Org secret prerequisite
Before merging, create these org secrets at komune-io (seeded from legacy values):
FIXERS_SONAR_TOKEN, FIXERS_DOCKER_HUB_USERNAME/PASSWORD, FIXERS_PUBLISH_GRADLE_PORTAL_KEY/SECRET, FIXERS_PUBLISH_NPMJS_TOKEN

## Test plan
- [ ] `gradle -p plugin test` passes
- [ ] Verify consumer repos CI green after merging both this + PR #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gradle Plugin Portal credentials handling and SonarQube token bridge for in-process analysis.

* **Chores**
  * Standardized CI/CD secret and environment variable names to new FIXERS-prefixed entries; updated npm/Gradle publish auth wiring.

* **Documentation**
  * Documented Gradle Plugin Portal and Sonar token configuration and bridging behavior.

* **Tests**
  * Added unit and integration tests for credential handling, token propagation, and property-bridging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->