### PR TITLE
fix: stop passing sonar.sources/inclusions to the Gradle sonar scanner

### DIFF
--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/SonarQubeConfigurator.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/SonarQubeConfigurator.kt
@@ -82,13 +82,16 @@ class SonarQubeConfigurator(
 
         bundle?.name?.orNull?.let { properties["sonar.projectName"] = it }
 
-        properties["sonar.sources"] = sonar.sources.get()
+        // sonar.sources/sonar.inclusions are intentionally NOT set here: the Gradle
+        // sonar scanner derives sources and tests from each module's source sets, and
+        // a root-level sources="." + inclusions pattern makes files indexed twice.
+        // They remain part of the generated sonar-project.properties used by the
+        // standalone scanner (see GenerateSonarPropertiesTask).
         properties["sonar.projectKey"] = sonar.projectKey.get()
         properties["sonar.organization"] = sonar.organization.get()
         properties["sonar.host.url"] = sonar.url.get()
         properties["sonar.language"] = sonar.language.get()
         properties["sonar.exclusions"] = sonar.exclusions.get()
-        properties["sonar.inclusions"] = sonar.inclusions.get()
         properties["sonar.kotlin.detekt.reportPaths"] = sonar.detekt.get()
         properties["sonar.pullrequest.github.summary_comment"] = sonar.githubSummaryComment.get()
         properties["sonar.coverage.jacoco.xmlReportPaths"] = sonar.jacoco.get()

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/SonarQubeConfiguratorTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/SonarQubeConfiguratorTest.kt
@@ -46,9 +46,11 @@ class SonarQubeConfiguratorTest {
             assertThat(properties["sonar.projectKey"]).isEqualTo("my-project")
             assertThat(properties["sonar.host.url"]).isEqualTo("https://sonarcloud.io")
             assertThat(properties["sonar.language"]).isEqualTo("kotlin")
-            assertThat(properties["sonar.sources"]).isEqualTo("src/main")
+            // sources/inclusions must not reach the Gradle scanner: it derives them
+            // from module source sets, and setting them causes double indexing.
+            assertThat(properties).doesNotContainKey("sonar.sources")
+            assertThat(properties).doesNotContainKey("sonar.inclusions")
             assertThat(properties["sonar.exclusions"]).isEqualTo("**/generated/**")
-            assertThat(properties["sonar.inclusions"]).isEqualTo("**/*.kt")
             assertThat(properties["sonar.verbose"]).isEqualTo(true)
         }
 


### PR DESCRIPTION
Running `./gradlew sonar` (e.g. via a `make check` step in the libs job) fails with:

> File ... can't be indexed twice. Please check that inclusion/exclusion patterns produce disjoint sets for main and test files

because `SonarQubeConfigurator` pushes the root-level `sonar.sources=.` + `sonar.inclusions=**/src/*main*/kotlin/**/*.kt` into the Gradle `SonarExtension`, while the Gradle scanner already derives sources/tests from each module's source sets.

This PR stops setting those two properties on the extension. They remain in the generated `sonar-project.properties` (`GenerateSonarPropertiesTask`), which the standalone scanner action still needs.

Consumers can then drop the workaround override (`sonar.sources=""`) added in komune-io/fixers-s2#93, komune-io/fixers-c2#100 and komune-io/fixers-f2#114.

Unit tests updated; check-plugin test suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SonarQube analysis configuration by preventing Gradle-based scans from applying source and inclusion settings that could lead to incorrect analysis results.
  * Existing exclusion settings remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->