### PR TITLE
feat: add with-sonarcloud toggle to sec workflow

### DIFF
--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -25,6 +25,12 @@ on:
         required: false
         type: "string"
 
+      with-sonarcloud:
+        description: "Flag to run the SonarCloud analysis job. Disable when the repository runs the analysis via the Gradle sonar task instead."
+        required: false
+        default: true
+        type: "boolean"
+
     secrets:
       FIXERS_SONAR_TOKEN:
         required: true
@@ -61,6 +67,7 @@ jobs:
           build-scan-terms-of-use-agree: "yes"
 
   sonarcloud-analysis:
+    if: ${{ inputs.with-sonarcloud }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adds a `with-sonarcloud` boolean input (default `true`, fully backwards compatible) to `sec-workflow.yml`. Repositories that now run SonarCloud analysis via the Gradle `sonar` task in the libs `check` step (komune-io/fixers-s2#93, komune-io/fixers-c2#100, komune-io/fixers-f2#114) can pass `with-sonarcloud: false` to skip the redundant scanner-action job while keeping `gradle-dependency-analysis`.

Note: consumer PRs setting this input will fail workflow validation until this is merged (they reference `sec-workflow.yml@main`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to enable or disable SonarCloud analysis in security workflows.
  * SonarCloud analysis remains enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->