### PR TITLE
fix: checkout full history in make-jvm-workflow for Sonar new-code detection

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -169,6 +169,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          # Full history so the Sonar Gradle scanner can blame files and detect
+          # new code against the target branch during pull request analysis.
+          fetch-depth: 0
 
       - name: Add Firefox to Run Kotlin test
         uses: browser-actions/setup-firefox@v1


### PR DESCRIPTION
With the SonarCloud analysis now running via the Gradle `sonar` task inside the libs job (`make check`), the scanner needs git history and the target branch ref for SCM blame and pull-request new-code detection. The job's default shallow checkout (`fetch-depth: 1`) makes it log `Could not find ref 'main'` and classify the entire codebase as new code — on komune-io/fixers-s2#93 the PR gate reported 1467 new lines to cover across 98 files for a CI-only diff.

Sets `fetch-depth: 0` on the checkout, matching what `sec-workflow.yml` already does for the scanner-action path.