### PR TITLE
test: SonarQube cleanup and coverage to 92%

### DIFF
--- a/build-composite/build.gradle.kts
+++ b/build-composite/build.gradle.kts
@@ -57,6 +57,9 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // Unit tests must be deterministic regardless of ambient release credentials:
+    // FIXERS_* env vars are read as property conventions by the config models.
+    setEnvironment(environment.filterKeys { !it.startsWith("FIXERS_") })
     testLogging {
         events("passed", "skipped", "failed")
     }

--- a/build-composite/build.gradle.kts
+++ b/build-composite/build.gradle.kts
@@ -60,6 +60,11 @@ tasks.test {
     // Unit tests must be deterministic regardless of ambient release credentials:
     // FIXERS_* env vars are read as property conventions by the config models.
     setEnvironment(environment.filterKeys { !it.startsWith("FIXERS_") })
+    // Controlled env values for PropertyUtils env-priority tests
+    environment("PROPERTY_UTILS_TEST_STRING", "env-value")
+    environment("PROPERTY_UTILS_TEST_INT", "42")
+    environment("PROPERTY_UTILS_TEST_BOOL", "true")
+    environment("PROPERTY_UTILS_TEST_LIST", "a, b ,c")
     testLogging {
         events("passed", "skipped", "failed")
     }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishMppSetup.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishMppSetup.kt
@@ -25,7 +25,8 @@ object PublishMppSetup {
 	private fun Project.setupPublication(config: ConfigExtension) {
 		val projectName = name
 
-		//TODO Check correction of https://github.com/gradle/gradle/issues/26091
+		// Workaround for https://github.com/gradle/gradle/issues/26091:
+		// publish tasks must be ordered after signing tasks explicitly.
 		tasks.withType<AbstractPublishToMaven>().configureEach {
 			val signingTasks = tasks.withType<Sign>()
 			mustRunAfter(signingTasks)

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/CompositePluginsTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/CompositePluginsTest.kt
@@ -1,0 +1,35 @@
+package io.komune.fixers.gradle
+
+import io.komune.fixers.gradle.plugin.check.CheckPlugin
+import io.komune.fixers.gradle.plugin.config.ConfigPlugin
+import io.komune.fixers.gradle.plugin.publish.PublishPlugin
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the composite precompiled script plugins.
+ */
+class CompositePluginsTest {
+
+    @Test
+    fun `composite config should apply check and config plugins`() {
+        val project = ProjectBuilder.builder().build()
+
+        project.plugins.apply("composite.config")
+
+        assertThat(project.plugins.hasPlugin(CheckPlugin::class.java)).isTrue()
+        assertThat(project.plugins.hasPlugin(ConfigPlugin::class.java)).isTrue()
+    }
+
+    @Test
+    fun `composite publishing should apply publish plugin`() {
+        val root = ProjectBuilder.builder().build()
+        val child = ProjectBuilder.builder().withParent(root).build()
+
+        child.plugins.apply("composite.publishing")
+
+        assertThat(child.plugins.hasPlugin(PublishPlugin::class.java)).isTrue()
+        assertThat(child.plugins.hasPlugin("maven-publish")).isTrue()
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginLifecycleTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginLifecycleTest.kt
@@ -1,0 +1,59 @@
+package io.komune.fixers.gradle.check
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.plugin.check.CheckPlugin
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.internal.GradleInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the CheckPlugin projectsEvaluated behaviour.
+ */
+class CheckPluginLifecycleTest {
+
+    private fun fireProjectsEvaluated(project: Project) {
+        val gradle = project.gradle as GradleInternal
+        gradle.buildListenerBroadcaster.projectsEvaluated(gradle)
+    }
+
+    @Test
+    fun `should configure sonar detekt and subproject jacoco after evaluation`() {
+        val root = ProjectBuilder.builder().build()
+        root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        val child = ProjectBuilder.builder().withParent(root).build()
+        child.plugins.apply("java")
+        root.plugins.apply(CheckPlugin::class.java)
+
+        fireProjectsEvaluated(root)
+
+        assertThat(root.plugins.hasPlugin("org.sonarqube")).isTrue()
+        assertThat(root.tasks.findByName("generateSonarProperties")).isNotNull
+        assertThat(root.tasks.findByName("detektReportMergeXml")).isNotNull
+        assertThat(child.plugins.hasPlugin("jacoco")).isTrue()
+    }
+
+    @Test
+    fun `should skip detekt configuration when disabled`() {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        config.detekt.disable.set(true)
+        root.plugins.apply(CheckPlugin::class.java)
+
+        fireProjectsEvaluated(root)
+
+        assertThat(root.plugins.hasPlugin("org.sonarqube")).isTrue()
+        assertThat(root.tasks.findByName("detektReportMergeXml")).isNull()
+    }
+
+    @Test
+    fun `should work without fixers configuration`() {
+        val root = ProjectBuilder.builder().build()
+        root.plugins.apply(CheckPlugin::class.java)
+
+        fireProjectsEvaluated(root)
+
+        assertThat(root.plugins.hasPlugin("org.sonarqube")).isTrue()
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/DetektConfigurationTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/DetektConfigurationTest.kt
@@ -1,0 +1,124 @@
+package io.komune.fixers.gradle.check
+
+import dev.detekt.gradle.Detekt
+import dev.detekt.gradle.extensions.DetektExtension
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.plugin.check.configureDetekt
+import io.komune.fixers.gradle.plugin.check.getDetektReportMergeXmlFile
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Unit tests for the Detekt configuration helpers.
+ */
+class DetektConfigurationTest {
+
+    private fun rootWithConfig(dir: File? = null): Pair<Project, ConfigExtension> {
+        val builder = ProjectBuilder.builder()
+        if (dir != null) {
+            builder.withProjectDir(dir)
+        }
+        val root = builder.build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        return root to config
+    }
+
+    @Test
+    fun `should point merge xml file into root build directory`() {
+        val (root, _) = rootWithConfig()
+
+        val mergeFile = root.getDetektReportMergeXmlFile()
+
+        assertThat(mergeFile.get().asFile.path).endsWith("reports/detekt/merge.xml")
+    }
+
+    @Test
+    fun `should register merge tasks and apply detekt plugin to all projects`() {
+        val (root, _) = rootWithConfig()
+        val child = ProjectBuilder.builder().withParent(root).build()
+
+        root.configureDetekt()
+
+        assertThat(root.tasks.findByName("detektReportMergeSarif")).isNotNull
+        assertThat(root.tasks.findByName("detektReportMergeXml")).isNotNull
+        assertThat(root.plugins.hasPlugin("dev.detekt")).isTrue()
+        assertThat(child.plugins.hasPlugin("dev.detekt")).isTrue()
+    }
+
+    @Test
+    fun `should configure detekt extension with defaults`() {
+        val (root, _) = rootWithConfig()
+
+        root.configureDetekt()
+
+        val detekt = root.extensions.getByType(DetektExtension::class.java)
+        assertThat(detekt.buildUponDefaultConfig.get()).isTrue()
+        // No detekt.yml in the project dir: the built-in default config is used
+        assertThat(detekt.config.files).isEmpty()
+    }
+
+    @Test
+    fun `should use detekt config file when present in root dir`(@TempDir dir: File) {
+        val configFile = File(dir, "detekt.yml")
+        configFile.writeText("build:\n  maxIssues: 0\n")
+        val (root, _) = rootWithConfig(dir)
+
+        root.configureDetekt()
+
+        val detekt = root.extensions.getByType(DetektExtension::class.java)
+        assertThat(detekt.config.files.map { it.canonicalFile }).containsExactly(configFile.canonicalFile)
+    }
+
+    @Test
+    fun `should set baseline when configured`(@TempDir dir: File) {
+        val (root, config) = rootWithConfig(dir)
+        config.detekt.baseline.set("detekt-baseline.xml")
+
+        root.configureDetekt()
+
+        val detekt = root.extensions.getByType(DetektExtension::class.java)
+        assertThat(detekt.baseline.get().asFile.name).isEqualTo("detekt-baseline.xml")
+    }
+
+    @Test
+    fun `should configure report outputs on detekt tasks`() {
+        val (root, _) = rootWithConfig()
+
+        root.configureDetekt()
+
+        val detektTasks = root.tasks.withType(Detekt::class.java)
+        assertThat(detektTasks).isNotEmpty
+        detektTasks.forEach { task ->
+            assertThat(task.reports.checkstyle.required.get()).isTrue()
+            assertThat(task.reports.checkstyle.outputLocation.get().asFile.path)
+                .endsWith("reports/detekt/detekt.xml")
+            assertThat(task.reports.sarif.required.get()).isTrue()
+            assertThat(task.reports.html.required.get()).isTrue()
+            assertThat(task.reports.markdown.required.get()).isTrue()
+        }
+    }
+
+    @Test
+    fun `should disable reports when configured off`() {
+        val (root, config) = rootWithConfig()
+        config.detekt.checkstyleReport.set(false)
+        config.detekt.sarifReport.set(false)
+        config.detekt.htmlReport.set(false)
+        config.detekt.markdownReport.set(false)
+
+        root.configureDetekt()
+
+        val detektTasks = root.tasks.withType(Detekt::class.java)
+        assertThat(detektTasks).isNotEmpty
+        detektTasks.forEach { task ->
+            assertThat(task.reports.checkstyle.required.get()).isFalse()
+            assertThat(task.reports.sarif.required.get()).isFalse()
+            assertThat(task.reports.html.required.get()).isFalse()
+            assertThat(task.reports.markdown.required.get()).isFalse()
+        }
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/JacocoConfiguratorMppTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/JacocoConfiguratorMppTest.kt
@@ -1,0 +1,99 @@
+package io.komune.fixers.gradle.check
+
+import io.komune.fixers.gradle.config.model.Jacoco
+import io.komune.fixers.gradle.plugin.check.JacocoConfigurator
+import io.komune.fixers.gradle.plugin.kotlin.MppPlugin
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for JacocoConfigurator on multiplatform projects and version overrides.
+ */
+class JacocoConfiguratorMppTest {
+
+    private fun mppProject(): Project {
+        val root = ProjectBuilder.builder().build()
+        val project = ProjectBuilder.builder().withParent(root).withName("mpp-lib").build()
+        project.plugins.apply(MppPlugin::class.java)
+        return project
+    }
+
+    @Test
+    fun `should register jacocoJvmTestReport for multiplatform projects`() {
+        val project = mppProject()
+        val configurator = JacocoConfigurator(project)
+
+        configurator.configure(Jacoco(project))
+
+        assertThat(project.plugins.hasPlugin("jacoco")).isTrue()
+        val report = project.tasks.findByName("jacocoJvmTestReport") as JacocoReport?
+        assertThat(report).isNotNull
+        assertThat(report!!.reports.xml.outputLocation.get().asFile.path)
+            .endsWith("reports/jacoco/jvmTest/${Jacoco.DEFAULT_XML_REPORT_FILENAME}")
+    }
+
+    @Test
+    fun `should use custom xml report filename for multiplatform report`() {
+        val project = mppProject()
+        val configurator = JacocoConfigurator(project)
+        val jacoco = Jacoco(project).apply {
+            xmlReportFilename.set("custom.xml")
+        }
+
+        configurator.configure(jacoco)
+
+        val report = project.tasks.findByName("jacocoJvmTestReport") as JacocoReport
+        assertThat(report.reports.xml.outputLocation.get().asFile.path).endsWith("jvmTest/custom.xml")
+    }
+
+    @Test
+    fun `should do nothing for multiplatform when jacoco is disabled`() {
+        val project = mppProject()
+        val configurator = JacocoConfigurator(project)
+        val jacoco = Jacoco(project).apply { enabled.set(false) }
+
+        configurator.configure(jacoco)
+
+        assertThat(project.plugins.hasPlugin("jacoco")).isFalse()
+        assertThat(project.tasks.findByName("jacocoJvmTestReport")).isNull()
+    }
+
+    @Test
+    fun `should return early when project has no multiplatform extension`() {
+        val project = ProjectBuilder.builder().build()
+        val configurator = JacocoConfigurator(project)
+
+        configurator.configureJacocoForMultiplatform(Jacoco(project))
+
+        assertThat(project.tasks.findByName("jacocoJvmTestReport")).isNull()
+    }
+
+    @Test
+    fun `should configure tool version from config`() {
+        val project = ProjectBuilder.builder().build()
+        val configurator = JacocoConfigurator(project)
+        val jacoco = Jacoco(project).apply { version.set("0.8.11") }
+
+        configurator.applyJacocoPlugin(jacoco)
+
+        val extension = project.extensions.getByType(JacocoPluginExtension::class.java)
+        assertThat(extension.toolVersion).isEqualTo("0.8.11")
+    }
+
+    @Test
+    fun `should finalize test tasks with jacoco report on jvm projects`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("java")
+        val configurator = JacocoConfigurator(project)
+
+        configurator.configure(Jacoco(project))
+
+        val test = project.tasks.getByName("test")
+        val finalizers = test.finalizedBy.getDependencies(test).map { it.name }
+        assertThat(finalizers).contains("jacocoTestReport")
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/FixersExtensionTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/FixersExtensionTest.kt
@@ -1,0 +1,96 @@
+package io.komune.fixers.gradle.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.plugin.use.PluginDependenciesSpec
+import org.gradle.plugin.use.PluginDependencySpec
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the fixers extension accessors and PublishConfig helpers.
+ */
+class FixersExtensionTest {
+
+    @Test
+    fun `fixers accessor should return null when extension is absent`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertThat(project.extensions.fixers).isNull()
+    }
+
+    @Test
+    fun `fixers accessor should return the registered extension`() {
+        val project = ProjectBuilder.builder().build()
+        val config = project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)
+
+        assertThat(project.extensions.fixers).isSameAs(config)
+    }
+
+    @Test
+    fun `Project fixers should configure the root extension from a subproject`() {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        val child = ProjectBuilder.builder().withParent(root).build()
+
+        child.fixers { bundle.description.set("configured-from-child") }
+
+        assertThat(config.bundle.description.get()).isEqualTo("configured-from-child")
+    }
+
+    @Test
+    fun `fixersIfExists should run the action only when the extension exists`() {
+        val project = ProjectBuilder.builder().build()
+        var executed = false
+
+        project.extensions.fixersIfExists { executed = true }
+        assertThat(executed).isFalse()
+
+        project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)
+        project.extensions.fixersIfExists { executed = true }
+        assertThat(executed).isTrue()
+    }
+
+    @Test
+    fun `PluginDependenciesSpec fixers should prefix the komune plugin id`() {
+        val requestedIds = mutableListOf<String>()
+        val spec = object : PluginDependenciesSpec {
+            override fun id(id: String): PluginDependencySpec {
+                requestedIds.add(id)
+                return object : PluginDependencySpec {
+                    override fun version(version: String?): PluginDependencySpec = this
+                    override fun apply(apply: Boolean): PluginDependencySpec = this
+                }
+            }
+        }
+
+        spec.fixers("kotlin.jvm")
+
+        assertThat(requestedIds).containsExactly("io.komune.fixers.gradle.kotlin.jvm")
+    }
+
+    @Test
+    fun `PublishConfig getStagingRepositoryPath should resolve into build directory`() {
+        val project = ProjectBuilder.builder().build()
+        val config = project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)
+
+        val path = config.publish.getStagingRepositoryPath(project)
+
+        assertThat(path).endsWith("staging-deploy")
+        assertThat(path).contains(project.layout.buildDirectory.get().asFile.name)
+    }
+
+    @Test
+    fun `PublishConfig toString should mask secrets`() {
+        val project = ProjectBuilder.builder().build()
+        val config = project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)
+        config.publish.pkgGithubToken.set("secret-token")
+        config.publish.npmjsToken.set("npm-secret")
+
+        val str = config.publish.toString()
+
+        assertThat(str).doesNotContain("secret-token")
+        assertThat(str).doesNotContain("npm-secret")
+        assertThat(str).contains("pkgGithubToken=******")
+        assertThat(str).contains("npmjsToken=******")
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/model/ConfigModelsTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/model/ConfigModelsTest.kt
@@ -1,0 +1,231 @@
+package io.komune.fixers.gradle.config.model
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for config model defaults and mergeFrom behaviour.
+ */
+class ConfigModelsTest {
+
+    private lateinit var project: Project
+
+    @BeforeEach
+    fun setup() {
+        project = ProjectBuilder.builder().build()
+    }
+
+    @Nested
+    inner class NpmModelTest {
+
+        @Test
+        fun `should have publishing enabled with komune defaults`() {
+            val npm = Npm(project)
+
+            assertThat(npm.publish.get()).isTrue()
+            assertThat(npm.organization.get()).isEqualTo("komune-io")
+            assertThat(npm.clean.get()).isTrue()
+            assertThat(npm.tag.get()).isEqualTo("next")
+            assertThat(npm.version.isPresent).isFalse()
+        }
+
+        @Test
+        fun `should merge absent values only`() {
+            val source = Npm(project).apply {
+                version.set("1.0.0")
+                tag.set("beta")
+            }
+            val target = Npm(project).apply {
+                tag.set("alpha")
+            }
+
+            target.mergeFrom(source)
+
+            assertThat(target.version.get()).isEqualTo("1.0.0")
+            assertThat(target.tag.get()).isEqualTo("alpha")
+        }
+    }
+
+    @Nested
+    inner class DetektModelTest {
+
+        @Test
+        fun `should have sensible defaults`() {
+            val detekt = Detekt(project)
+
+            assertThat(detekt.disable.get()).isFalse()
+            assertThat(detekt.config.get()).isEqualTo("detekt.yml")
+            assertThat(detekt.buildUponDefaultConfig.get()).isTrue()
+            assertThat(detekt.checkstyleReport.get()).isTrue()
+            assertThat(detekt.baseline.isPresent).isFalse()
+        }
+
+        @Test
+        fun `should merge absent values only`() {
+            val source = Detekt(project).apply {
+                baseline.set("baseline.xml")
+                config.set("custom.yml")
+            }
+            val target = Detekt(project).apply {
+                config.set("target.yml")
+            }
+
+            target.mergeFrom(source)
+
+            assertThat(target.baseline.get()).isEqualTo("baseline.xml")
+            assertThat(target.config.get()).isEqualTo("target.yml")
+        }
+    }
+
+    @Nested
+    inner class Kt2TsModelTest {
+
+        @Test
+        fun `should default output directory and empty additional cleaning`() {
+            val kt2Ts = Kt2Ts(project)
+
+            assertThat(kt2Ts.outputDirectory.get()).isEqualTo("platform/web/kotlin")
+            assertThat(kt2Ts.inputDirectory.isPresent).isFalse()
+            assertThat(kt2Ts.additionalCleaning.get()).isEmpty()
+        }
+
+        @Test
+        fun `should merge absent values only`() {
+            val source = Kt2Ts(project).apply {
+                inputDirectory.set("build/js/packages")
+                outputDirectory.set("source-out")
+            }
+            val target = Kt2Ts(project).apply {
+                outputDirectory.set("target-out")
+            }
+
+            target.mergeFrom(source)
+
+            assertThat(target.inputDirectory.get()).isEqualTo("build/js/packages")
+            assertThat(target.outputDirectory.get()).isEqualTo("target-out")
+        }
+    }
+
+    @Nested
+    inner class JdkModelTest {
+
+        @Test
+        fun `should default to jdk 17`() {
+            assertThat(Jdk(project).version.get()).isEqualTo(Jdk.VERSION_DEFAULT)
+            assertThat(Jdk.VERSION_DEFAULT).isEqualTo(17)
+        }
+
+        @Test
+        fun `should keep explicitly set version on merge`() {
+            val source = Jdk(project).apply { version.set(11) }
+            val target = Jdk(project).apply { version.set(21) }
+
+            target.mergeFrom(source)
+
+            assertThat(target.version.get()).isEqualTo(21)
+        }
+    }
+
+    @Nested
+    inner class RepositoriesModelTest {
+
+        @Test
+        fun `should default to maven central only`() {
+            val repos = Repositories(project)
+
+            assertThat(repos.mavenLocal.get()).isFalse()
+            assertThat(repos.mavenCentral.get()).isTrue()
+            assertThat(repos.sonatypeSnapshots.get()).isFalse()
+            assertThat(repos.mavenUrls.get()).isEmpty()
+        }
+
+        @Test
+        fun `should collect custom maven urls`() {
+            val repos = Repositories(project)
+
+            repos.maven("https://repo.example.com/a")
+            repos.maven("https://repo.example.com/b")
+
+            assertThat(repos.mavenUrls.get())
+                .containsExactly("https://repo.example.com/a", "https://repo.example.com/b")
+        }
+
+        @Test
+        fun `should not override convention-backed flags on merge`() {
+            // All flags have conventions, so isPresent is always true and
+            // mergeIfNotPresent keeps the target defaults.
+            val source = Repositories(project).apply { mavenLocal.set(true) }
+            val target = Repositories(project)
+
+            target.mergeFrom(source)
+
+            assertThat(target.mavenLocal.get()).isFalse()
+        }
+    }
+
+    @Nested
+    inner class PublicationModelTest {
+
+        @Test
+        fun `should merge configure action when absent`() {
+            val source = Publication(project).apply {
+                configure.set(org.gradle.api.Action { })
+            }
+            val target = Publication(project)
+
+            target.mergeFrom(source)
+
+            assertThat(target.configure.isPresent).isTrue()
+        }
+
+        @Test
+        fun `should keep existing configure action on merge`() {
+            val sourceAction = org.gradle.api.Action<org.gradle.api.publish.maven.MavenPom> { }
+            val targetAction = org.gradle.api.Action<org.gradle.api.publish.maven.MavenPom> { }
+            val source = Publication(project).apply { configure.set(sourceAction) }
+            val target = Publication(project).apply { configure.set(targetAction) }
+
+            target.mergeFrom(source)
+
+            assertThat(target.configure.get()).isSameAs(targetAction)
+        }
+    }
+
+    @Nested
+    inner class ConfigExtensionDslTest {
+
+        private fun createConfig(): ConfigExtension =
+            project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)
+
+        @Test
+        fun `should configure kt2Ts npm jdk publish and repositories via DSL`() {
+            val config = createConfig()
+
+            config.kt2Ts { outputDirectory.set("custom/out") }
+            config.npm { organization.set("custom-org") }
+            config.jdk { version.set(21) }
+            config.publish { pkgGithubUsername.set("user") }
+            config.repositories { mavenLocal.set(true) }
+
+            assertThat(config.kt2Ts.outputDirectory.get()).isEqualTo("custom/out")
+            assertThat(config.npm.organization.get()).isEqualTo("custom-org")
+            assertThat(config.jdk.version.get()).isEqualTo(21)
+            assertThat(config.publish.pkgGithubUsername.get()).isEqualTo("user")
+            assertThat(config.repositories.mavenLocal.get()).isTrue()
+        }
+
+        @Test
+        fun `should store pom action via DSL`() {
+            val config = createConfig()
+
+            config.pom { }
+
+            assertThat(config.pom.configure.isPresent).isTrue()
+        }
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/utils/PomUtilsTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/utils/PomUtilsTest.kt
@@ -1,0 +1,105 @@
+package io.komune.fixers.gradle.config.utils
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.config.model.Bundle
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [pom] POM configuration action.
+ */
+class PomUtilsTest {
+
+    private fun projectWithPublishing(root: Project? = null): Pair<Project, MavenPublication> {
+        val project = if (root == null) {
+            ProjectBuilder.builder().build()
+        } else {
+            ProjectBuilder.builder().withParent(root).build()
+        }
+        project.plugins.apply("maven-publish")
+        val publication = project.extensions.getByType(PublishingExtension::class.java)
+            .publications.create("test", MavenPublication::class.java)
+        return project to publication
+    }
+
+    @Test
+    fun `should populate pom from bundle values`() {
+        val (project, publication) = projectWithPublishing()
+        val bundle = Bundle(project, "my-bundle").apply {
+            description.set("My description")
+            url.set("https://example.com/project")
+        }
+
+        publication.pom(project.pom(bundle))
+
+        assertThat(publication.pom.name.get()).isEqualTo("my-bundle")
+        assertThat(publication.pom.description.get()).isEqualTo("My description")
+        assertThat(publication.pom.url.get()).isEqualTo("https://example.com/project")
+    }
+
+    @Test
+    fun `should leave optional values absent when not configured anywhere`() {
+        val (project, publication) = projectWithPublishing()
+        val bundle = Bundle(project, "my-bundle")
+
+        publication.pom(project.pom(bundle))
+
+        assertThat(publication.pom.description.orNull).isNull()
+        assertThat(publication.pom.url.orNull).isNull()
+    }
+
+    @Test
+    fun `should fall back to root project bundle for missing values`() {
+        val root = ProjectBuilder.builder().build()
+        val rootConfig = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        rootConfig.bundle.description.set("Root description")
+        rootConfig.bundle.url.set("https://root.example.com")
+
+        val (project, publication) = projectWithPublishing(root)
+        val bundle = Bundle(project, "sub-bundle")
+
+        publication.pom(project.pom(bundle))
+
+        assertThat(publication.pom.name.get()).isEqualTo("sub-bundle")
+        assertThat(publication.pom.description.get()).isEqualTo("Root description")
+        assertThat(publication.pom.url.get()).isEqualTo("https://root.example.com")
+    }
+
+    @Test
+    fun `should prefer subproject bundle values over root fallback`() {
+        val root = ProjectBuilder.builder().build()
+        val rootConfig = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        rootConfig.bundle.description.set("Root description")
+
+        val (project, publication) = projectWithPublishing(root)
+        val bundle = Bundle(project, "sub-bundle").apply {
+            description.set("Sub description")
+        }
+
+        publication.pom(project.pom(bundle))
+
+        assertThat(publication.pom.description.get()).isEqualTo("Sub description")
+    }
+
+    @Test
+    fun `should execute license developer and scm defaults without error`() {
+        val (project, publication) = projectWithPublishing()
+        val bundle = Bundle(project, "my-bundle").apply {
+            url.set("https://example.com/project")
+        }
+
+        // Defaults exist for license, developer and scm fields; the action must apply them.
+        publication.pom(project.pom(bundle))
+
+        // MavenPom does not expose getters for nested sections; assert via generated XML actions
+        // being registered without failure and top-level values applied.
+        assertThat(publication.pom.url.get()).isEqualTo("https://example.com/project")
+        assertThat(bundle.licenseName.get()).isEqualTo("The Apache Software License, Version 2.0")
+        assertThat(bundle.developerId.get()).isEqualTo("Komune")
+        assertThat(bundle.scmConnection.get()).contains("scm:git")
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/utils/PropertyUtilsTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/utils/PropertyUtilsTest.kt
@@ -1,0 +1,131 @@
+package io.komune.fixers.gradle.config.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the property initialization helpers.
+ */
+class PropertyUtilsTest {
+
+    private fun projectWithProperties(vararg pairs: Pair<String, Any>): Project {
+        val project = ProjectBuilder.builder().build()
+        pairs.forEach { (key, value) -> project.extensions.extraProperties.set(key, value) }
+        return project
+    }
+
+    @Nested
+    inner class StringPropertyTest {
+
+        @Test
+        fun `should use default value when nothing is configured`() {
+            val project = projectWithProperties()
+
+            val property = project.property<String>(
+                projectKey = "fixers.test.value",
+                defaultValue = "default"
+            )
+
+            assertThat(property.get()).isEqualTo("default")
+        }
+
+        @Test
+        fun `should read value from project property`() {
+            val project = projectWithProperties("fixers.test.value" to "from-project")
+
+            val property = project.property<String>(
+                projectKey = "fixers.test.value",
+                defaultValue = "default"
+            )
+
+            assertThat(property.get()).isEqualTo("from-project")
+        }
+
+        @Test
+        fun `should be absent when nothing is configured and no default given`() {
+            val project = projectWithProperties()
+
+            val property = project.property<String>(projectKey = "fixers.test.value")
+
+            assertThat(property.isPresent).isFalse()
+        }
+
+        @Test
+        fun `should allow dsl value to override convention`() {
+            val project = projectWithProperties("fixers.test.value" to "from-project")
+
+            val property = project.property<String>(projectKey = "fixers.test.value")
+            property.set("from-dsl")
+
+            assertThat(property.get()).isEqualTo("from-dsl")
+        }
+    }
+
+    @Nested
+    inner class TypedPropertyTest {
+
+        @Test
+        fun `should convert project property to Int`() {
+            val project = projectWithProperties("fixers.test.int" to "42")
+
+            val property = project.property<Int>(projectKey = "fixers.test.int")
+
+            assertThat(property.get()).isEqualTo(42)
+        }
+
+        @Test
+        fun `should convert project property to Boolean`() {
+            val project = projectWithProperties("fixers.test.bool" to "true")
+
+            val property = project.property<Boolean>(projectKey = "fixers.test.bool", defaultValue = false)
+
+            assertThat(property.get()).isTrue()
+        }
+
+        @Test
+        fun `should keep Int default when no property is set`() {
+            val project = projectWithProperties()
+
+            val property = project.property<Int>(projectKey = "fixers.test.int", defaultValue = 7)
+
+            assertThat(property.get()).isEqualTo(7)
+        }
+    }
+
+    @Nested
+    inner class ListPropertyTest {
+
+        @Test
+        fun `should split comma separated project property`() {
+            val project = projectWithProperties("fixers.test.list" to "a, b ,c")
+
+            val property = project.initListProperty<String>(projectKey = "fixers.test.list")
+
+            assertThat(property.get()).containsExactly("a", "b", "c")
+        }
+
+        @Test
+        fun `should use default list when nothing is configured`() {
+            val project = projectWithProperties()
+
+            val property = project.initListProperty(
+                projectKey = "fixers.test.list",
+                defaultValue = listOf("x", "y")
+            )
+
+            assertThat(property.get()).containsExactly("x", "y")
+        }
+
+        @Test
+        fun `should be empty when nothing is configured and no default given`() {
+            val project = projectWithProperties()
+
+            val property = project.initListProperty<String>(projectKey = "fixers.test.list")
+
+            assertThat(property.get()).isEmpty()
+        }
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/utils/PropertyUtilsTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/utils/PropertyUtilsTest.kt
@@ -96,6 +96,68 @@ class PropertyUtilsTest {
     }
 
     @Nested
+    inner class EnvironmentPriorityTest {
+
+        @Test
+        fun `should prefer environment variable over project property and default`() {
+            val project = projectWithProperties("fixers.test.value" to "from-project")
+
+            val property = project.property<String>(
+                envKey = "PROPERTY_UTILS_TEST_STRING",
+                projectKey = "fixers.test.value",
+                defaultValue = "default"
+            )
+
+            assertThat(property.get()).isEqualTo("env-value")
+        }
+
+        @Test
+        fun `should convert environment variable to Int`() {
+            val project = projectWithProperties()
+
+            val property = project.property<Int>(envKey = "PROPERTY_UTILS_TEST_INT")
+
+            assertThat(property.get()).isEqualTo(42)
+        }
+
+        @Test
+        fun `should convert environment variable to Boolean`() {
+            val project = projectWithProperties()
+
+            val property = project.property<Boolean>(
+                envKey = "PROPERTY_UTILS_TEST_BOOL",
+                defaultValue = false
+            )
+
+            assertThat(property.get()).isTrue()
+        }
+
+        @Test
+        fun `should split environment variable for list properties`() {
+            val project = projectWithProperties("fixers.test.list" to "x,y")
+
+            val property = project.initListProperty<String>(
+                envKey = "PROPERTY_UTILS_TEST_LIST",
+                projectKey = "fixers.test.list"
+            )
+
+            assertThat(property.get()).containsExactly("a", "b", "c")
+        }
+
+        @Test
+        fun `should fall back to project property when env variable is missing`() {
+            val project = projectWithProperties("fixers.test.value" to "from-project")
+
+            val property = project.property<String>(
+                envKey = "PROPERTY_UTILS_TEST_MISSING",
+                projectKey = "fixers.test.value"
+            )
+
+            assertThat(property.get()).isEqualTo("from-project")
+        }
+    }
+
+    @Nested
     inner class ListPropertyTest {
 
         @Test

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/dependencies/DependenciesPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/dependencies/DependenciesPluginTest.kt
@@ -1,0 +1,45 @@
+package io.komune.fixers.gradle.dependencies
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the (no-op) DependenciesPlugin variants and catalog extensions.
+ */
+class DependenciesPluginTest {
+
+    @Test
+    fun `should apply dependencies plugin without side effects`() {
+        val project = ProjectBuilder.builder().build()
+
+        project.plugins.apply(DependenciesPlugin::class.java)
+
+        assertThat(project.plugins.hasPlugin(DependenciesPlugin::class.java)).isTrue()
+    }
+
+    @Test
+    fun `should apply plugin variant from plugin package`() {
+        val project = ProjectBuilder.builder().build()
+
+        project.plugins.apply(io.komune.fixers.gradle.plugin.dependencies.DependenciesPlugin::class.java)
+
+        assertThat(
+            project.plugins.hasPlugin(io.komune.fixers.gradle.plugin.dependencies.DependenciesPlugin::class.java)
+        ).isTrue()
+    }
+
+    @Test
+    fun `hasFixersCatalog should be false without version catalogs`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertThat(project.hasFixersCatalog()).isFalse()
+    }
+
+    @Test
+    fun `findFixersCatalog should return null without version catalogs`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertThat(project.findFixersCatalog()).isNull()
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/config/ConfigPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/config/ConfigPluginTest.kt
@@ -1,0 +1,177 @@
+package io.komune.fixers.gradle.plugin.config
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.config.fixers
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.internal.GradleInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Unit tests for ConfigPlugin and the Project.config() extension.
+ */
+class ConfigPluginTest {
+
+    private fun fireProjectsEvaluated(project: Project) {
+        val gradle = project.gradle as GradleInternal
+        gradle.buildListenerBroadcaster.projectsEvaluated(gradle)
+    }
+
+    @Nested
+    inner class ApplyTest {
+
+        @Test
+        fun `should apply base plugin and create fixers extension`() {
+            val project = ProjectBuilder.builder().build()
+
+            project.plugins.apply(ConfigPlugin::class.java)
+
+            assertThat(project.plugins.hasPlugin("base")).isTrue()
+            assertThat(project.extensions.fixers).isNotNull
+        }
+
+        @Test
+        fun `should not reapply base plugin when already present`() {
+            val project = ProjectBuilder.builder().build()
+            project.plugins.apply("base")
+
+            project.plugins.apply(ConfigPlugin::class.java)
+
+            assertThat(project.plugins.hasPlugin(ConfigPlugin::class.java)).isTrue()
+        }
+
+        @Test
+        fun `should set version from VERSION file on root and subprojects`(@TempDir dir: File) {
+            File(dir, "VERSION").writeText("9.9.9\n")
+            val root = ProjectBuilder.builder().withProjectDir(dir).build()
+            val child = ProjectBuilder.builder().withParent(root).build()
+
+            root.plugins.apply(ConfigPlugin::class.java)
+
+            assertThat(root.version.toString()).isEqualTo("9.9.9")
+            assertThat(child.version.toString()).isEqualTo("9.9.9")
+        }
+
+        @Test
+        fun `should keep project version when no VERSION file exists`() {
+            val root = ProjectBuilder.builder().build()
+            root.version = "1.2.3"
+
+            root.plugins.apply(ConfigPlugin::class.java)
+
+            assertThat(root.version.toString()).isEqualTo("1.2.3")
+        }
+    }
+
+    @Nested
+    inner class ProjectsEvaluatedTest {
+
+        @Test
+        fun `should propagate bundle group to root and subprojects`() {
+            val root = ProjectBuilder.builder().build()
+            val child = ProjectBuilder.builder().withParent(root).build()
+            root.plugins.apply(ConfigPlugin::class.java)
+            root.extensions.fixers!!.bundle.group.set("io.komune.test")
+
+            fireProjectsEvaluated(root)
+
+            assertThat(root.group).isEqualTo("io.komune.test")
+            assertThat(child.group).isEqualTo("io.komune.test")
+        }
+
+        @Test
+        fun `should merge root config into subprojects`() {
+            val root = ProjectBuilder.builder().build()
+            val child = ProjectBuilder.builder().withParent(root).build()
+            root.plugins.apply(ConfigPlugin::class.java)
+            root.extensions.fixers!!.bundle.description.set("Root description")
+            root.extensions.fixers!!.publish.pkgGithubUsername.set("root-user")
+
+            fireProjectsEvaluated(root)
+
+            val childConfig = child.extensions.fixers
+            assertThat(childConfig).isNotNull
+            assertThat(childConfig!!.bundle.description.get()).isEqualTo("Root description")
+            assertThat(childConfig.publish.pkgGithubUsername.get()).isEqualTo("root-user")
+        }
+
+        @Test
+        fun `should configure maven central repository by default`() {
+            val root = ProjectBuilder.builder().build()
+            root.plugins.apply(ConfigPlugin::class.java)
+
+            fireProjectsEvaluated(root)
+
+            val urls = root.repositories.filterIsInstance<MavenArtifactRepository>().map { it.url.toString() }
+            assertThat(urls).anyMatch { it.contains("repo.maven.apache.org") }
+        }
+
+        @Test
+        fun `should configure custom maven urls and sonatype snapshots when enabled`() {
+            val root = ProjectBuilder.builder().build()
+            root.plugins.apply(ConfigPlugin::class.java)
+            val config = root.extensions.fixers!!
+            config.repositories.sonatypeSnapshots.set(true)
+            config.repositories.maven("https://repo.example.com/custom")
+
+            fireProjectsEvaluated(root)
+
+            val urls = root.repositories.filterIsInstance<MavenArtifactRepository>().map { it.url.toString() }
+            assertThat(urls).anyMatch { it.contains("central.sonatype.com/repository/maven-snapshots") }
+            assertThat(urls).contains("https://repo.example.com/custom")
+        }
+
+        @Test
+        fun `should configure mavenLocal only when enabled`() {
+            val root = ProjectBuilder.builder().build()
+            root.plugins.apply(ConfigPlugin::class.java)
+            root.extensions.fixers!!.repositories.mavenLocal.set(true)
+
+            fireProjectsEvaluated(root)
+
+            assertThat(root.repositories.findByName("MavenLocal")).isNotNull
+        }
+
+        @Test
+        fun `should register kt2Ts tasks`() {
+            val root = ProjectBuilder.builder().build()
+            root.plugins.apply(ConfigPlugin::class.java)
+
+            fireProjectsEvaluated(root)
+
+            assertThat(root.tasks.findByName("cleanTsGen")).isNotNull
+            assertThat(root.tasks.findByName("tsGen")).isNotNull
+        }
+    }
+
+    @Nested
+    inner class ConfigExtensionFunctionTest {
+
+        @Test
+        fun `should create extension on first call and reuse it afterwards`() {
+            val project = ProjectBuilder.builder().build()
+
+            val first = project.config()
+            val second = project.config()
+
+            assertThat(first).isSameAs(second)
+            assertThat(project.extensions.findByType(ConfigExtension::class.java)).isSameAs(first)
+        }
+
+        @Test
+        fun `should apply configuration block`() {
+            val project = ProjectBuilder.builder().build()
+
+            val config = project.config {
+                bundle.description.set("configured")
+            }
+
+            assertThat(config.bundle.description.get()).isEqualTo("configured")
+        }
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/config/TsGenTaskTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/config/TsGenTaskTest.kt
@@ -1,0 +1,190 @@
+package io.komune.fixers.gradle.plugin.config
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.config.model.Kt2Ts
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Unit tests for the kt2Ts task registration and TypeScript cleaning rules.
+ */
+class TsGenTaskTest {
+
+    private fun projectWithConfig(): Pair<Project, ConfigExtension> {
+        val project = ProjectBuilder.builder().build()
+        val config = project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)
+        return project to config
+    }
+
+    @Nested
+    inner class ConfigureKt2TsTest {
+
+        @Test
+        fun `should register cleanTsGen and tsGen tasks`() {
+            val (project, config) = projectWithConfig()
+
+            project.configureKt2Ts(config)
+
+            assertThat(project.tasks.findByName("cleanTsGen")).isNotNull
+            val tsGen = project.tasks.findByName("tsGen")
+            assertThat(tsGen).isNotNull
+            assertThat(tsGen!!.dependsOn).contains("cleanTsGen")
+        }
+
+        @Test
+        fun `should use explicit input directory when configured`(@TempDir dir: File) {
+            val (project, config) = projectWithConfig()
+            config.kt2Ts.inputDirectory.set(dir.absolutePath)
+
+            project.configureKt2Ts(config)
+
+            assertThat(project.tasks.findByName("tsGen")).isNotNull
+        }
+
+        @Test
+        fun `should register no tasks when config is null`() {
+            val (project, _) = projectWithConfig()
+
+            project.configureKt2Ts(null)
+
+            assertThat(project.tasks.findByName("tsGen")).isNull()
+            assertThat(project.tasks.findByName("cleanTsGen")).isNull()
+        }
+    }
+
+    @Nested
+    inner class BuildCleaningRegexTest {
+
+        private fun kt2Ts(): Kt2Ts = Kt2Ts(ProjectBuilder.builder().build())
+
+        @Test
+        fun `should provide cleaning rules for dts dmts and package json`() {
+            val cleaning = kt2Ts().buildCleaningRegex()
+
+            assertThat(cleaning.keys).contains(".d.ts", ".d.mts", "package.json")
+            assertThat(cleaning[".d.ts"]).isNotEmpty
+            assertThat(cleaning[".d.mts"]).isNotEmpty
+        }
+
+        @Test
+        fun `should append additional cleaning rules to existing suffix`() {
+            val kt2Ts = kt2Ts()
+            kt2Ts.additionalCleaning.set(mapOf(".d.ts" to listOf(Regex("FOO") to "BAR")))
+
+            val cleaning = kt2Ts.buildCleaningRegex()
+
+            assertThat(cleaning[".d.ts"]!!.map { it.first.pattern }).contains("FOO")
+        }
+
+        @Test
+        fun `should add additional cleaning rules for new suffixes`() {
+            val kt2Ts = kt2Ts()
+            kt2Ts.additionalCleaning.set(mapOf(".custom" to listOf(Regex("A") to "B")))
+
+            val cleaning = kt2Ts.buildCleaningRegex()
+
+            assertThat(cleaning).containsKey(".custom")
+        }
+    }
+
+    @Nested
+    inner class CleanProjectDirTest {
+
+        @TempDir
+        lateinit var dir: File
+
+        private fun clean(fileName: String, content: String): String {
+            val file = File(dir, fileName)
+            file.writeText(content)
+            val cleaning = Kt2Ts(ProjectBuilder.builder().build()).buildCleaningRegex()
+            cleanProjectDir(dir.absolutePath, cleaning)
+            return file.readText()
+        }
+
+        @Test
+        fun `should strip kotlin namespaces in dts files`() {
+            val result = clean(
+                "api.d.ts",
+                "type A = kotlin.js.PromiseLike;\nreadonly items: kotlin.collections.List<string>;\n"
+            )
+
+            assertThat(result).contains("type A = PromiseLike;")
+            assertThat(result).contains("readonly items: string[];")
+        }
+
+        @Test
+        fun `should map kotlin collections and numbers in dts files`() {
+            val result = clean(
+                "model.d.ts",
+                "value: kotlin.Long;\nprops: kotlin.collections.Map<string, string>;\n"
+            )
+
+            assertThat(result).contains("value: number;")
+            assertThat(result).contains("props: Record<string, string>;")
+        }
+
+        @Test
+        fun `should remove doNotImplementIt markers in dts files`() {
+            val result = clean(
+                "marker.d.ts",
+                "interface A {\n    readonly __doNotUseOrImplementIt: unique symbol;\n    name: string;\n}\n"
+            )
+
+            assertThat(result).doesNotContain("__doNotUseOrImplementIt")
+            assertThat(result).contains("name: string;")
+        }
+
+        @Test
+        fun `should clean KtList KtMap and bigint in dmts files`() {
+            val result = clean(
+                "api.d.mts",
+                "items: KtList<string>;\nprops: KtMap<string, string>;\ncount: bigint;\n"
+            )
+
+            assertThat(result).contains("items: string[];")
+            assertThat(result).contains("props: Record<string, string>;")
+            assertThat(result).contains("count: number;")
+        }
+
+        @Test
+        fun `should rewrite nullable properties in dmts files`() {
+            val result = clean(
+                "nullable.d.mts",
+                "interface A {\n    readonly label: Nullable<string>;\n}\n"
+            )
+
+            assertThat(result).contains("readonly label?: string;")
+        }
+
+        @Test
+        fun `should empty devDependencies in package json`() {
+            val result = clean(
+                "package.json",
+                """{"name": "pkg", "devDependencies": {"typescript": "^5.0.0"}, "version": "1.0.0"}"""
+            )
+
+            assertThat(result).contains(""""devDependencies": {},""")
+            assertThat(result).doesNotContain("typescript")
+        }
+
+        @Test
+        fun `should leave unmatched files untouched`() {
+            val content = "kotlin.Long should stay"
+            val result = clean("readme.txt", content)
+
+            assertThat(result).isEqualTo(content)
+        }
+
+        @Test
+        fun `should tolerate missing directories`() {
+            val cleaning = Kt2Ts(ProjectBuilder.builder().build()).buildCleaningRegex()
+
+            cleanProjectDir(File(dir, "does-not-exist").absolutePath, cleaning)
+        }
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/kotlin/JvmPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/kotlin/JvmPluginTest.kt
@@ -1,0 +1,90 @@
+package io.komune.fixers.gradle.plugin.kotlin
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.plugin.config.ConfigPlugin
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test as TestTask
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
+import org.gradle.jvm.tasks.Jar
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for JvmPlugin (and the setupJarInfo/configureJUnitPlatform helpers it applies).
+ */
+class JvmPluginTest {
+
+    private fun jvmProject(configure: (ConfigExtension) -> Unit = {}): Project {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        configure(config)
+        val project = ProjectBuilder.builder().withParent(root).withName("jvm-lib").build()
+        project.plugins.apply(JvmPlugin::class.java)
+        return project
+    }
+
+    @Test
+    fun `should apply java kotlin and config plugins`() {
+        val project = jvmProject()
+
+        assertThat(project.plugins.hasPlugin("java")).isTrue()
+        assertThat(project.plugins.hasPlugin("org.jetbrains.kotlin.jvm")).isTrue()
+        assertThat(project.plugins.hasPlugin(ConfigPlugin::class.java)).isTrue()
+    }
+
+    @Test
+    fun `should configure java toolchain with default jdk version`() {
+        val project = jvmProject()
+
+        val java = project.extensions.getByType(JavaPluginExtension::class.java)
+        assertThat(java.toolchain.languageVersion.get().asInt()).isEqualTo(17)
+    }
+
+    @Test
+    fun `should configure java toolchain with configured jdk version`() {
+        val project = jvmProject { config -> config.jdk.version.set(21) }
+
+        val java = project.extensions.getByType(JavaPluginExtension::class.java)
+        assertThat(java.toolchain.languageVersion.get().asInt()).isEqualTo(21)
+    }
+
+    @Test
+    fun `should configure kotlin compiler options`() {
+        val project = jvmProject()
+
+        val kotlin = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+        assertThat(kotlin.compilerOptions.jvmTarget.get()).isEqualTo(JvmTarget.JVM_17)
+        assertThat(kotlin.compilerOptions.freeCompilerArgs.get()).contains("-Xjsr305=strict")
+        assertThat(kotlin.compilerOptions.languageVersion.orNull).isNotNull
+    }
+
+    @Test
+    fun `should add kotlin reflect dependency`() {
+        val project = jvmProject()
+
+        val implementation = project.configurations.getByName("implementation")
+        assertThat(implementation.dependencies.map { it.name }).contains("kotlin-reflect")
+    }
+
+    @Test
+    fun `should configure test tasks to use junit platform`() {
+        val project = jvmProject()
+
+        val test = project.tasks.getByName("test") as TestTask
+        assertThat(test.options).isInstanceOf(JUnitPlatformOptions::class.java)
+    }
+
+    @Test
+    fun `should add implementation info to jar manifest`() {
+        val project = jvmProject()
+        project.version = "1.2.3"
+
+        val jar = project.tasks.getByName("jar") as Jar
+        assertThat(jar.manifest.attributes["Implementation-Title"]).isEqualTo("jvm-lib")
+        assertThat(jar.manifest.attributes["Implementation-Version"]).isEqualTo(project.version)
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/kotlin/MppPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/kotlin/MppPluginTest.kt
@@ -1,0 +1,85 @@
+package io.komune.fixers.gradle.plugin.kotlin
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.jvm.tasks.Jar
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for MppPlugin and MppJsPlugin.
+ */
+class MppPluginTest {
+
+    private fun mppProject(configure: (ConfigExtension) -> Unit = {}): Project {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        configure(config)
+        val project = ProjectBuilder.builder().withParent(root).withName("mpp-lib").build()
+        project.plugins.apply(MppPlugin::class.java)
+        return project
+    }
+
+    @Test
+    fun `should apply kotlin multiplatform and js plugins`() {
+        val project = mppProject()
+
+        assertThat(project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")).isTrue()
+        assertThat(project.plugins.hasPlugin(MppJsPlugin::class.java)).isTrue()
+    }
+
+    @Test
+    fun `should define jvm and js targets`() {
+        val project = mppProject()
+
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        assertThat(kotlin.targets.names).contains("jvm", "js")
+    }
+
+    @Test
+    fun `should create common and target source sets`() {
+        val project = mppProject()
+
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        assertThat(kotlin.sourceSets.names).contains("commonMain", "jvmMain", "jsMain", "jsTest")
+    }
+
+    @Test
+    fun `should configure jvm compilation with default jdk version`() {
+        val project = mppProject()
+
+        val compileJvm = project.tasks.getByName("compileKotlinJvm") as KotlinCompile
+        assertThat(compileJvm.compilerOptions.jvmTarget.get()).isEqualTo(JvmTarget.JVM_17)
+    }
+
+    @Test
+    fun `should configure jvm compilation with configured jdk version`() {
+        val project = mppProject { config -> config.jdk.version.set(21) }
+
+        val compileJvm = project.tasks.getByName("compileKotlinJvm") as KotlinCompile
+        assertThat(compileJvm.compilerOptions.jvmTarget.get()).isEqualTo(JvmTarget.JVM_21)
+    }
+
+    @Test
+    fun `should configure js compilation for es2015 with export flags`() {
+        val project = mppProject()
+
+        val compileJs = project.tasks.getByName("compileKotlinJs") as Kotlin2JsCompile
+        assertThat(compileJs.compilerOptions.target.get()).isEqualTo("es2015")
+        assertThat(compileJs.compilerOptions.freeCompilerArgs.get())
+            .contains("-Xes-long-as-bigint", "-Xenable-suspend-function-exporting")
+    }
+
+    @Test
+    fun `should add implementation info to jvm jar manifest`() {
+        val project = mppProject()
+
+        val jar = project.tasks.getByName("jvmJar") as Jar
+        assertThat(jar.manifest.attributes["Implementation-Title"]).isEqualTo("mpp-lib")
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/kotlin/TargetTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/kotlin/TargetTest.kt
@@ -1,0 +1,95 @@
+package io.komune.fixers.gradle.plugin.kotlin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.extra
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the Target enum helpers.
+ */
+class TargetTest {
+
+    private fun projectWithTarget(target: String? = null): Project {
+        val project = ProjectBuilder.builder().build()
+        if (target != null) {
+            project.extra.set("target", target)
+        }
+        return project
+    }
+
+    @Nested
+    inner class CurrentTargetTest {
+
+        @Test
+        fun `should default to ALL when no target property is set`() {
+            assertThat(Target.currentTarget(projectWithTarget())).isEqualTo(Target.ALL)
+        }
+
+        @Test
+        fun `should resolve target property case-insensitively`() {
+            assertThat(Target.currentTarget(projectWithTarget("jvm"))).isEqualTo(Target.JVM)
+            assertThat(Target.currentTarget(projectWithTarget("JS"))).isEqualTo(Target.JS)
+            assertThat(Target.currentTarget(projectWithTarget("Meta"))).isEqualTo(Target.META)
+        }
+
+        @Test
+        fun `should fall back to ALL for unknown target values`() {
+            assertThat(Target.currentTarget(projectWithTarget("wasm"))).isEqualTo(Target.ALL)
+        }
+    }
+
+    @Nested
+    inner class ShouldDefineTargetTest {
+
+        @Test
+        fun `ALL should define every target`() {
+            val project = projectWithTarget("all")
+            assertThat(Target.shouldDefineTarget(project, Target.JVM)).isTrue()
+            assertThat(Target.shouldDefineTarget(project, Target.JS)).isTrue()
+            assertThat(Target.shouldDefineTarget(project, Target.META)).isTrue()
+        }
+
+        @Test
+        fun `JVM should define only JVM`() {
+            val project = projectWithTarget("jvm")
+            assertThat(Target.shouldDefineTarget(project, Target.JVM)).isTrue()
+            assertThat(Target.shouldDefineTarget(project, Target.JS)).isFalse()
+        }
+
+        @Test
+        fun `META should define every target`() {
+            val project = projectWithTarget("meta")
+            assertThat(Target.shouldDefineTarget(project, Target.JVM)).isTrue()
+            assertThat(Target.shouldDefineTarget(project, Target.JS)).isTrue()
+        }
+    }
+
+    @Nested
+    inner class ShouldPublishTargetTest {
+
+        @Test
+        fun `META should publish only META`() {
+            val project = projectWithTarget("meta")
+            assertThat(Target.shouldPublishTarget(project, Target.META)).isTrue()
+            assertThat(Target.shouldPublishTarget(project, Target.JVM)).isFalse()
+            assertThat(Target.shouldPublishTarget(project, Target.JS)).isFalse()
+        }
+
+        @Test
+        fun `ALL should publish every target`() {
+            val project = projectWithTarget("all")
+            assertThat(Target.shouldPublishTarget(project, Target.JVM)).isTrue()
+            assertThat(Target.shouldPublishTarget(project, Target.JS)).isTrue()
+        }
+
+        @Test
+        fun `JVM should publish only JVM`() {
+            val project = projectWithTarget("jvm")
+            assertThat(Target.shouldPublishTarget(project, Target.JVM)).isTrue()
+            assertThat(Target.shouldPublishTarget(project, Target.JS)).isFalse()
+        }
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/npm/NpmPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/npm/NpmPluginTest.kt
@@ -1,0 +1,87 @@
+package io.komune.fixers.gradle.plugin.npm
+
+import dev.petuska.npm.publish.NpmPublishPlugin
+import dev.petuska.npm.publish.extension.NpmPublishExtension
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.plugin.npm.task.NpmTsGenTask
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for NpmPlugin.
+ */
+class NpmPluginTest {
+
+    private fun evaluatedNpmProject(
+        version: String = "1.0.0",
+        configure: (ConfigExtension) -> Unit = {}
+    ): Project {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        configure(config)
+        val project = ProjectBuilder.builder().withParent(root).withName("npm-lib").build()
+        project.version = version
+        project.plugins.apply(NpmPlugin::class.java)
+        (project as ProjectInternal).evaluate()
+        return project
+    }
+
+    @Test
+    fun `should apply npm publish plugin and configure registries`() {
+        val project = evaluatedNpmProject()
+
+        assertThat(project.plugins.hasPlugin(NpmPublishPlugin::class.java)).isTrue()
+        val npm = project.extensions.getByType(NpmPublishExtension::class.java)
+        assertThat(npm.organization.get()).isEqualTo("komune-io")
+        assertThat(npm.version.get()).isEqualTo("1.0.0")
+        assertThat(npm.registries.names).contains("npmjs", "github")
+    }
+
+    @Test
+    fun `should prefer configured npm version over project version`() {
+        val project = evaluatedNpmProject { config -> config.npm.version.set("2.5.0") }
+
+        val npm = project.extensions.getByType(NpmPublishExtension::class.java)
+        assertThat(npm.version.get()).isEqualTo("2.5.0")
+    }
+
+    @Test
+    fun `should register npmTsGenTask in build group`() {
+        val project = evaluatedNpmProject()
+
+        val task = project.tasks.findByName("npmTsGenTask")
+        assertThat(task).isNotNull
+        assertThat(task!!.group).isEqualTo("build")
+        assertThat(task).isInstanceOf(NpmTsGenTask::class.java)
+    }
+
+    @Test
+    fun `should skip configuration when npm publish is disabled`() {
+        val project = evaluatedNpmProject { config -> config.npm.publish.set(false) }
+
+        assertThat(project.plugins.hasPlugin(NpmPublishPlugin::class.java)).isFalse()
+        assertThat(project.tasks.findByName("npmTsGenTask")).isNull()
+    }
+
+    @Test
+    fun `should skip configuration when root has no fixers config`() {
+        val root = ProjectBuilder.builder().build()
+        val project = ProjectBuilder.builder().withParent(root).build()
+        project.plugins.apply(NpmPlugin::class.java)
+
+        (project as ProjectInternal).evaluate()
+
+        assertThat(project.plugins.hasPlugin(NpmPublishPlugin::class.java)).isFalse()
+    }
+
+    @Test
+    fun `should configure prerelease versions without failure`() {
+        val project = evaluatedNpmProject(version = "1.0.0-SNAPSHOT.abc123")
+
+        val npm = project.extensions.getByType(NpmPublishExtension::class.java)
+        assertThat(npm.version.get()).isEqualTo("1.0.0-SNAPSHOT.abc123")
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/npm/task/NpmTsGenTaskTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/npm/task/NpmTsGenTaskTest.kt
@@ -1,0 +1,43 @@
+package io.komune.fixers.gradle.plugin.npm.task
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Unit tests for NpmTsGenTask.
+ */
+class NpmTsGenTaskTest {
+
+    @TempDir
+    lateinit var buildDir: File
+
+    @Test
+    fun `should clean files in build directory using configured regexes`() {
+        val file = File(buildDir, "api.d.ts")
+        file.writeText("value: kotlin.Long;")
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("npmTsGenTask", NpmTsGenTask::class.java).get()
+        task.buildDir = buildDir.absolutePath
+        task.cleaning = mapOf(".d.ts" to listOf(Regex("""kotlin\.Long""") to "number"))
+
+        task.doAction()
+
+        assertThat(file.readText()).isEqualTo("value: number;")
+    }
+
+    @Test
+    fun `should be a no-op with empty cleaning configuration`() {
+        val file = File(buildDir, "api.d.ts")
+        file.writeText("value: kotlin.Long;")
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("npmTsGenTask", NpmTsGenTask::class.java).get()
+        task.buildDir = buildDir.absolutePath
+
+        task.doAction()
+
+        assertThat(file.readText()).isEqualTo("value: kotlin.Long;")
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/CentralPortalUploaderTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/CentralPortalUploaderTest.kt
@@ -1,0 +1,152 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import com.sun.net.httpserver.HttpServer
+import java.io.File
+import java.net.InetSocketAddress
+import java.util.zip.ZipInputStream
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.gradle.api.GradleException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Unit tests for CentralPortalUploader against a local HTTP server.
+ */
+class CentralPortalUploaderTest {
+
+    @TempDir
+    lateinit var stagingDir: File
+
+    private lateinit var server: HttpServer
+    private var requestPath: String? = null
+    private var requestQuery: String? = null
+    private var authHeader: String? = null
+    private var requestBody: ByteArray = ByteArray(0)
+    private var responseCode: Int = 200
+    private var responseBody: String = "deployment-id-123"
+
+    @BeforeEach
+    fun startServer() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        server.createContext("/") { exchange ->
+            requestPath = exchange.requestURI.path
+            requestQuery = exchange.requestURI.query
+            authHeader = exchange.requestHeaders.getFirst("Authorization")
+            requestBody = exchange.requestBody.readBytes()
+            val bytes = responseBody.toByteArray()
+            exchange.sendResponseHeaders(responseCode, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+    }
+
+    @AfterEach
+    fun stopServer() {
+        server.stop(0)
+    }
+
+    private fun baseUrl() = "http://localhost:${server.address.port}"
+
+    private fun createStagingFile(relativePath: String, content: String = "artifact-content") {
+        val file = File(stagingDir, relativePath)
+        file.parentFile.mkdirs()
+        file.writeText(content)
+    }
+
+    @Test
+    fun `should upload zip bundle with bearer token and automatic publishing`() {
+        createStagingFile("io/komune/test/1.0/test-1.0.jar")
+
+        CentralPortalUploader.upload(stagingDir, baseUrl(), "user", "pass", "my-bundle")
+
+        assertThat(requestPath).isEqualTo("/upload")
+        assertThat(requestQuery).isEqualTo("publishingType=AUTOMATIC")
+        val expectedToken = java.util.Base64.getEncoder().encodeToString("user:pass".toByteArray())
+        assertThat(authHeader).isEqualTo("Bearer $expectedToken")
+        assertThat(String(requestBody)).contains("filename=\"my-bundle.zip\"")
+    }
+
+    @Test
+    fun `should zip staging directory content preserving relative paths`() {
+        createStagingFile("io/komune/test/1.0/test-1.0.jar", "jar-bytes")
+        createStagingFile("io/komune/test/1.0/test-1.0.pom", "pom-bytes")
+
+        CentralPortalUploader.upload(stagingDir, baseUrl(), "user", "pass")
+
+        val zipBytes = extractZipFromMultipart(requestBody)
+        val entries = mutableMapOf<String, String>()
+        ZipInputStream(zipBytes.inputStream()).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                entries[entry.name] = String(zis.readBytes())
+                entry = zis.nextEntry
+            }
+        }
+        assertThat(entries.keys).containsExactlyInAnyOrder(
+            "io/komune/test/1.0/test-1.0.jar",
+            "io/komune/test/1.0/test-1.0.pom"
+        )
+        assertThat(entries["io/komune/test/1.0/test-1.0.jar"]).isEqualTo("jar-bytes")
+    }
+
+    @Test
+    fun `should skip upload when staging directory is empty`() {
+        CentralPortalUploader.upload(stagingDir, baseUrl(), "user", "pass")
+
+        assertThat(requestPath).isNull()
+    }
+
+    @Test
+    fun `should skip upload when staging directory does not exist`() {
+        val missing = File(stagingDir, "missing")
+
+        CentralPortalUploader.upload(missing, baseUrl(), "user", "pass")
+
+        assertThat(requestPath).isNull()
+    }
+
+    @Test
+    fun `should throw GradleException with body on http error`() {
+        createStagingFile("artifact.jar")
+        responseCode = 401
+        responseBody = "Unauthorized access"
+
+        assertThatThrownBy {
+            CentralPortalUploader.upload(stagingDir, baseUrl(), "user", "bad-pass")
+        }
+            .isInstanceOf(GradleException::class.java)
+            .hasMessageContaining("HTTP 401")
+            .hasMessageContaining("Unauthorized access")
+    }
+
+    private fun extractZipFromMultipart(body: ByteArray): ByteArray {
+        // Zip content starts after the multipart headers (double CRLF) and
+        // ends before the trailing CRLF + closing boundary.
+        val headerEnd = body.indexOfSequence("\r\n\r\n".toByteArray()) + 4
+        val closingBoundaryStart = body.lastIndexOfSequence("\r\n--".toByteArray())
+        return body.copyOfRange(headerEnd, closingBoundaryStart)
+    }
+
+    private fun ByteArray.indexOfSequence(sequence: ByteArray): Int {
+        outer@ for (i in 0..(size - sequence.size)) {
+            for (j in sequence.indices) {
+                if (this[i + j] != sequence[j]) continue@outer
+            }
+            return i
+        }
+        return -1
+    }
+
+    private fun ByteArray.lastIndexOfSequence(sequence: ByteArray): Int {
+        outer@ for (i in (size - sequence.size) downTo 0) {
+            for (j in sequence.indices) {
+                if (this[i + j] != sequence[j]) continue@outer
+            }
+            return i
+        }
+        return -1
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/DefaultHttpPutClientTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/DefaultHttpPutClientTest.kt
@@ -1,0 +1,92 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import com.sun.net.httpserver.HttpServer
+import java.io.File
+import java.net.InetSocketAddress
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Unit tests for DefaultHttpPutClient against a local HTTP server.
+ */
+class DefaultHttpPutClientTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var server: HttpServer
+    private var requestMethod: String? = null
+    private var authHeader: String? = null
+    private var contentType: String? = null
+    private var requestBody: String? = null
+    private var responseCode: Int = 201
+    private var responseBody: String = ""
+
+    @BeforeEach
+    fun startServer() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        server.createContext("/") { exchange ->
+            requestMethod = exchange.requestMethod
+            authHeader = exchange.requestHeaders.getFirst("Authorization")
+            contentType = exchange.requestHeaders.getFirst("Content-Type")
+            requestBody = String(exchange.requestBody.readBytes())
+            val bytes = responseBody.toByteArray()
+            exchange.sendResponseHeaders(responseCode, if (bytes.isEmpty()) -1 else bytes.size.toLong())
+            if (bytes.isNotEmpty()) {
+                exchange.responseBody.use { it.write(bytes) }
+            } else {
+                exchange.responseBody.close()
+            }
+        }
+        server.start()
+    }
+
+    @AfterEach
+    fun stopServer() {
+        server.stop(0)
+    }
+
+    private fun url() = "http://localhost:${server.address.port}/repo/artifact.jar"
+
+    private fun artifactFile(content: String = "artifact-bytes"): File {
+        val file = File(tempDir, "artifact.jar")
+        file.writeText(content)
+        return file
+    }
+
+    @Test
+    fun `should PUT file content with auth header and return Success`() {
+        val result = DefaultHttpPutClient().put(url(), "Basic dXNlcjp0b2tlbg==", artifactFile("payload"))
+
+        assertThat(result).isEqualTo(HttpPutResult.Success)
+        assertThat(requestMethod).isEqualTo("PUT")
+        assertThat(authHeader).isEqualTo("Basic dXNlcjp0b2tlbg==")
+        assertThat(contentType).isEqualTo("application/octet-stream")
+        assertThat(requestBody).isEqualTo("payload")
+    }
+
+    @Test
+    fun `should return Conflict on http 409`() {
+        responseCode = 409
+
+        val result = DefaultHttpPutClient().put(url(), "Basic auth", artifactFile())
+
+        assertThat(result).isEqualTo(HttpPutResult.Conflict)
+    }
+
+    @Test
+    fun `should return Error with status and body on failure`() {
+        responseCode = 500
+        responseBody = "Internal failure"
+
+        val result = DefaultHttpPutClient().put(url(), "Basic auth", artifactFile())
+
+        assertThat(result).isInstanceOf(HttpPutResult.Error::class.java)
+        val error = result as HttpPutResult.Error
+        assertThat(error.code).isEqualTo(500)
+        assertThat(error.message).isEqualTo("Internal failure")
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishGradleModuleSetupTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishGradleModuleSetupTest.kt
@@ -1,0 +1,68 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for PublishGradleModuleSetup.
+ */
+class PublishGradleModuleSetupTest {
+
+    private fun projectWithPublishing(): Triple<Project, ConfigExtension, PublishingExtension> {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        config.bundle.url.set("https://example.com/project")
+        val project = ProjectBuilder.builder().withParent(root).withName("plugin-lib").build()
+        project.plugins.apply("maven-publish")
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        return Triple(project, config, publishing)
+    }
+
+    @Test
+    fun `should configure pluginMaven publication with maven central metadata`() {
+        val (project, config, publishing) = projectWithPublishing()
+        val pluginMaven = publishing.publications.create("pluginMaven", MavenPublication::class.java)
+
+        PublishGradleModuleSetup(project, config, publishing.publications).configurePluginPublications()
+
+        assertThat(pluginMaven.pom.url.get()).isEqualTo("https://example.com/project")
+    }
+
+    @Test
+    fun `should configure explicitly listed marker publications`() {
+        val (project, config, publishing) = projectWithPublishing()
+        config.publish.gradlePlugin.set(listOf("myMarker"))
+        val marker = publishing.publications.create("myMarker", MavenPublication::class.java)
+
+        PublishGradleModuleSetup(project, config, publishing.publications).configurePluginPublications()
+
+        assertThat(marker.pom.url.get()).isEqualTo("https://example.com/project")
+    }
+
+    @Test
+    fun `should configure all PluginMarkerMaven publications`() {
+        val (project, config, publishing) = projectWithPublishing()
+        val marker = publishing.publications.create("fooPluginMarkerMaven", MavenPublication::class.java)
+        val regular = publishing.publications.create("regular", MavenPublication::class.java)
+
+        PublishGradleModuleSetup(project, config, publishing.publications).configurePluginPublications()
+
+        assertThat(marker.pom.url.get()).isEqualTo("https://example.com/project")
+        assertThat(regular.pom.url.orNull).isNull()
+    }
+
+    @Test
+    fun `configureMavenPublications should apply pom metadata to all publications`() {
+        val (project, config, publishing) = projectWithPublishing()
+        val publication = publishing.publications.create("anything", MavenPublication::class.java)
+
+        publishing.publications.configureMavenPublications(project, config)
+
+        assertThat(publication.pom.url.get()).isEqualTo("https://example.com/project")
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetupTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetupTest.kt
@@ -1,0 +1,93 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.plugin.kotlin.JvmPlugin
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for PublishJvmSetup.
+ */
+class PublishJvmSetupTest {
+
+    private fun jvmProjectWithConfig(): Pair<Project, ConfigExtension> {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        val project = ProjectBuilder.builder().withParent(root).withName("jvm-lib").build()
+        project.plugins.apply(JvmPlugin::class.java)
+        project.plugins.apply("maven-publish")
+        return project to config
+    }
+
+    @Nested
+    inner class GetArtifactIdTest {
+
+        @Test
+        fun `should return project name for regular publications`() {
+            assertThat(PublishJvmSetup.getArtifactId("my-project", "maven")).isEqualTo("my-project")
+        }
+
+        @Test
+        fun `should map plugin marker publications to gradle plugin artifact id`() {
+            assertThat(PublishJvmSetup.getArtifactId("my-project", "fooPluginMarkerMaven"))
+                .isEqualTo("foo.gradle.plugin")
+        }
+    }
+
+    @Nested
+    inner class SetupJvmPublishTest {
+
+        @Test
+        fun `should register javadocJar and sourcesJar tasks`() {
+            val (project, config) = jvmProjectWithConfig()
+
+            PublishJvmSetup.setupJVMPublish(project, config)
+
+            assertThat(project.tasks.findByName("javadocJar")).isNotNull
+            assertThat(project.tasks.findByName("sourcesJar")).isNotNull
+        }
+
+        @Test
+        fun `should create maven publication from kotlin component`() {
+            val (project, config) = jvmProjectWithConfig()
+
+            PublishJvmSetup.setupJVMPublish(project, config)
+
+            val publishing = project.extensions.getByType(PublishingExtension::class.java)
+            val publication = publishing.publications.findByName("maven") as MavenPublication?
+            assertThat(publication).isNotNull
+            assertThat(publication!!.artifactId).isEqualTo("jvm-lib")
+        }
+
+        @Test
+        fun `should do nothing when JvmPlugin is not applied`() {
+            val root = ProjectBuilder.builder().build()
+            val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+            val project = ProjectBuilder.builder().withParent(root).build()
+            project.plugins.apply("maven-publish")
+
+            PublishJvmSetup.setupJVMPublish(project, config)
+
+            assertThat(project.tasks.findByName("javadocJar")).isNull()
+            val publishing = project.extensions.getByType(PublishingExtension::class.java)
+            assertThat(publishing.publications.findByName("maven")).isNull()
+        }
+
+        @Test
+        fun `should attach javadoc and sources artifacts to existing publications`() {
+            val (project, config) = jvmProjectWithConfig()
+
+            PublishJvmSetup.setupJVMPublish(project, config)
+
+            val publishing = project.extensions.getByType(PublishingExtension::class.java)
+            val publication = publishing.publications.getByName("maven") as MavenPublication
+            val classifiers = publication.artifacts.map { it.classifier }
+            assertThat(classifiers).contains("javadoc", "sources")
+        }
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishMppSetupTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishMppSetupTest.kt
@@ -1,0 +1,79 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.plugin.kotlin.MppPlugin
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for PublishMppSetup.
+ */
+class PublishMppSetupTest {
+
+    private fun mppProjectWithConfig(): Pair<Project, ConfigExtension> {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        val project = ProjectBuilder.builder().withParent(root).withName("mpp-lib").build()
+        project.plugins.apply(MppPlugin::class.java)
+        project.plugins.apply("maven-publish")
+        return project to config
+    }
+
+    @Test
+    fun `should register javadocJar task for mpp projects`() {
+        val (project, config) = mppProjectWithConfig()
+
+        PublishMppSetup.setupMppPublish(project, config)
+
+        assertThat(project.tasks.findByName("javadocJar")).isNotNull
+    }
+
+    @Test
+    fun `should suffix artifactId with publication name for target publications`() {
+        val (project, config) = mppProjectWithConfig()
+        PublishMppSetup.setupMppPublish(project, config)
+
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        val publication = publishing.publications.getByName("jvm") as MavenPublication
+
+        assertThat(publication.artifactId).isEqualTo("mpp-lib-jvm")
+    }
+
+    @Test
+    fun `should keep plain project name for kotlinMultiplatform publication`() {
+        val (project, config) = mppProjectWithConfig()
+        PublishMppSetup.setupMppPublish(project, config)
+
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        val publication = publishing.publications.getByName("kotlinMultiplatform") as MavenPublication
+
+        assertThat(publication.artifactId).isEqualTo("mpp-lib")
+    }
+
+    @Test
+    fun `should attach javadoc artifact to publications`() {
+        val (project, config) = mppProjectWithConfig()
+        PublishMppSetup.setupMppPublish(project, config)
+
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        val publication = publishing.publications.getByName("jvm") as MavenPublication
+
+        assertThat(publication.artifacts.map { it.classifier }).contains("javadoc")
+    }
+
+    @Test
+    fun `should do nothing when MppPlugin is not applied`() {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        val project = ProjectBuilder.builder().withParent(root).build()
+        project.plugins.apply("maven-publish")
+
+        PublishMppSetup.setupMppPublish(project, config)
+
+        assertThat(project.tasks.findByName("javadocJar")).isNull()
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlatformSetupTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlatformSetupTest.kt
@@ -1,0 +1,81 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for PublishPlatformSetup and PublishCatalogSetup.
+ */
+class PublishPlatformSetupTest {
+
+    private fun projectWithConfig(): Pair<Project, ConfigExtension> {
+        val root = ProjectBuilder.builder().build()
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        val project = ProjectBuilder.builder().withParent(root).withName("platform-lib").build()
+        return project to config
+    }
+
+    @Test
+    fun `should create maven publication for java-platform projects`() {
+        val (project, config) = projectWithConfig()
+        project.plugins.apply("java-platform")
+        project.plugins.apply("maven-publish")
+
+        PublishPlatformSetup.setupPlatformPublish(project, config)
+
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        assertThat(publishing.publications.findByName("maven")).isInstanceOf(MavenPublication::class.java)
+    }
+
+    @Test
+    fun `should not create publication when java-platform plugin is missing`() {
+        val (project, config) = projectWithConfig()
+        project.plugins.apply("maven-publish")
+
+        PublishPlatformSetup.setupPlatformPublish(project, config)
+
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        assertThat(publishing.publications.findByName("maven")).isNull()
+    }
+
+    @Test
+    fun `should not duplicate platform publication when called twice`() {
+        val (project, config) = projectWithConfig()
+        project.plugins.apply("java-platform")
+        project.plugins.apply("maven-publish")
+
+        PublishPlatformSetup.setupPlatformPublish(project, config)
+        PublishPlatformSetup.setupPlatformPublish(project, config)
+
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        assertThat(publishing.publications.filter { it.name == "maven" }).hasSize(1)
+    }
+
+    @Test
+    fun `should create maven publication for version-catalog projects`() {
+        val (project, config) = projectWithConfig()
+        project.plugins.apply("version-catalog")
+        project.plugins.apply("maven-publish")
+
+        PublishCatalogSetup.setupCatalogPublish(project, config)
+
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        assertThat(publishing.publications.findByName("maven")).isInstanceOf(MavenPublication::class.java)
+    }
+
+    @Test
+    fun `should not create publication when version-catalog plugin is missing`() {
+        val (project, config) = projectWithConfig()
+        project.plugins.apply("maven-publish")
+
+        PublishCatalogSetup.setupCatalogPublish(project, config)
+
+        val publishing = project.extensions.getByType(PublishingExtension::class.java)
+        assertThat(publishing.publications.findByName("maven")).isNull()
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPluginTest.kt
@@ -1,0 +1,377 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import groovy.util.Node
+import io.komune.fixers.gradle.config.ConfigExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for PublishPlugin: subproject wiring, root lifecycle tasks
+ * and POM dependency-version inlining.
+ */
+class PublishPluginTest {
+
+    private fun rootWithConfig(version: String = "1.0.0"): Pair<Project, ConfigExtension> {
+        val root = ProjectBuilder.builder().build()
+        root.version = version
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        return root to config
+    }
+
+    private fun childOf(root: Project, name: String = "lib"): Project =
+        ProjectBuilder.builder().withParent(root).withName(name).build()
+
+    private fun fireProjectsEvaluated(root: Project) {
+        val gradle = root.gradle as GradleInternal
+        gradle.buildListenerBroadcaster.projectsEvaluated(gradle)
+    }
+
+    @Nested
+    inner class SubprojectSetup {
+
+        @Test
+        fun `should apply maven-publish and signing plugins to subproject`() {
+            val (root, _) = rootWithConfig()
+            val child = childOf(root)
+
+            child.plugins.apply(PublishPlugin::class.java)
+
+            assertThat(child.plugins.hasPlugin("maven-publish")).isTrue()
+            assertThat(child.plugins.hasPlugin("signing")).isTrue()
+        }
+
+        @Test
+        fun `should configure staging and githubPackages repositories after evaluation`() {
+            val (root, config) = rootWithConfig()
+            val child = childOf(root)
+            child.plugins.apply(PublishPlugin::class.java)
+
+            (child as ProjectInternal).evaluate()
+
+            val publishing = child.extensions.getByType(PublishingExtension::class.java)
+            val staging = publishing.repositories.findByName("staging") as MavenArtifactRepository?
+            val github = publishing.repositories.findByName("githubPackages") as MavenArtifactRepository?
+
+            assertThat(staging).isNotNull
+            assertThat(staging!!.url.toString())
+                .contains(config.publish.stagingDirectory.get())
+                .contains(root.layout.buildDirectory.get().asFile.name)
+            assertThat(github).isNotNull
+            assertThat(github!!.url.toString()).isEqualTo(config.publish.githubPackagesUrl.get())
+        }
+
+        @Test
+        fun `should skip publishing configuration when root has no fixers config`() {
+            val root = ProjectBuilder.builder().build()
+            val child = childOf(root)
+            child.plugins.apply(PublishPlugin::class.java)
+
+            (child as ProjectInternal).evaluate()
+
+            val publishing = child.extensions.getByType(PublishingExtension::class.java)
+            assertThat(publishing.repositories.findByName("staging")).isNull()
+            assertThat(publishing.repositories.findByName("githubPackages")).isNull()
+        }
+
+        @Test
+        fun `should disable signing tasks when no signing key is configured`() {
+            val (root, _) = rootWithConfig()
+            val child = childOf(root)
+            child.plugins.apply(PublishPlugin::class.java)
+            child.extensions.getByType(PublishingExtension::class.java)
+                .publications.create("test", MavenPublication::class.java)
+
+            (child as ProjectInternal).evaluate()
+
+            val signTasks = child.tasks.withType(Sign::class.java)
+            assertThat(signTasks).allSatisfy { assertThat(it.enabled).isFalse() }
+        }
+
+        @Test
+        fun `should disable signing tasks when signing key is empty`() {
+            val (root, config) = rootWithConfig()
+            config.publish.signingGpgKey.set("")
+            config.publish.signingGpgKeyPassword.set("password")
+            val child = childOf(root)
+            child.plugins.apply(PublishPlugin::class.java)
+            child.extensions.getByType(PublishingExtension::class.java)
+                .publications.create("test", MavenPublication::class.java)
+
+            (child as ProjectInternal).evaluate()
+
+            val signTasks = child.tasks.withType(Sign::class.java)
+            assertThat(signTasks).allSatisfy { assertThat(it.enabled).isFalse() }
+        }
+
+        @Test
+        fun `should configure signing when key and password are provided`() {
+            val (root, config) = rootWithConfig()
+            config.publish.signingGpgKey.set("dummy-armored-key")
+            config.publish.signingGpgKeyPassword.set("password")
+            val child = childOf(root)
+            child.plugins.apply(PublishPlugin::class.java)
+            child.extensions.getByType(PublishingExtension::class.java)
+                .publications.create("test", MavenPublication::class.java)
+
+            (child as ProjectInternal).evaluate()
+
+            val signing = child.extensions.getByType(SigningExtension::class.java)
+            assertThat(signing.isRequired).isTrue()
+            assertThat(child.tasks.withType(Sign::class.java)).isNotEmpty
+        }
+    }
+
+    @Nested
+    inner class RootLifecycleTasks {
+
+        private fun evaluatedBuild(version: String): Project {
+            val (root, _) = rootWithConfig(version)
+            val child = childOf(root)
+            child.pluginManager.apply("io.komune.fixers.gradle.publish")
+            root.plugins.apply(PublishPlugin::class.java)
+            (child as ProjectInternal).evaluate()
+            fireProjectsEvaluated(root)
+            return root
+        }
+
+        @Test
+        fun `should register cleanStaging stage and promote tasks on root`() {
+            val root = evaluatedBuild("1.0.0")
+
+            assertThat(root.tasks.findByName("cleanStaging")).isNotNull
+            assertThat(root.tasks.findByName("stage")).isNotNull
+            assertThat(root.tasks.findByName("promote")).isNotNull
+        }
+
+        @Test
+        fun `should route promote to Central Portal for release versions`() {
+            val root = evaluatedBuild("1.0.0")
+
+            val promote = root.tasks.getByName("promote")
+            assertThat(promote.group).isEqualTo("publishing")
+            assertThat(promote.description).contains("Central Portal")
+        }
+
+        @Test
+        fun `should route promote to Maven Central Snapshots for snapshot versions`() {
+            val root = evaluatedBuild("1.0.0-SNAPSHOT")
+
+            val promote = root.tasks.getByName("promote")
+            assertThat(promote.description).contains("SNAPSHOT")
+        }
+
+        @Test
+        fun `should describe stage task as GitHub Packages publication`() {
+            val root = evaluatedBuild("1.0.0")
+
+            val stage = root.tasks.getByName("stage")
+            assertThat(stage.group).isEqualTo("publishing")
+            assertThat(stage.description).contains("GitHub Packages")
+        }
+
+        @Test
+        fun `should not register lifecycle tasks when no subproject applies the plugin`() {
+            val (root, _) = rootWithConfig()
+            childOf(root)
+            root.plugins.apply(PublishPlugin::class.java)
+            fireProjectsEvaluated(root)
+
+            assertThat(root.tasks.findByName("stage")).isNull()
+            assertThat(root.tasks.findByName("promote")).isNull()
+        }
+    }
+
+    @Nested
+    inner class GradlePortalCredentialsBridge {
+
+        @Test
+        fun `should bridge portal credentials to system properties`() {
+            val previousKey = System.getProperty("gradle.publish.key")
+            val previousSecret = System.getProperty("gradle.publish.secret")
+            System.clearProperty("gradle.publish.key")
+            System.clearProperty("gradle.publish.secret")
+            try {
+                val (root, config) = rootWithConfig()
+                config.publish.gradlePortalKey.set("portal-key")
+                config.publish.gradlePortalSecret.set("portal-secret")
+                root.plugins.apply(PublishPlugin::class.java)
+
+                fireProjectsEvaluated(root)
+
+                assertThat(System.getProperty("gradle.publish.key")).isEqualTo("portal-key")
+                assertThat(System.getProperty("gradle.publish.secret")).isEqualTo("portal-secret")
+            } finally {
+                restoreSystemProperty("gradle.publish.key", previousKey)
+                restoreSystemProperty("gradle.publish.secret", previousSecret)
+            }
+        }
+
+        @Test
+        fun `should not override explicitly set system properties`() {
+            val previousKey = System.getProperty("gradle.publish.key")
+            System.setProperty("gradle.publish.key", "explicit-key")
+            try {
+                val (root, config) = rootWithConfig()
+                config.publish.gradlePortalKey.set("portal-key")
+                root.plugins.apply(PublishPlugin::class.java)
+
+                fireProjectsEvaluated(root)
+
+                assertThat(System.getProperty("gradle.publish.key")).isEqualTo("explicit-key")
+            } finally {
+                restoreSystemProperty("gradle.publish.key", previousKey)
+            }
+        }
+
+        private fun restoreSystemProperty(key: String, value: String?) {
+            if (value == null) {
+                System.clearProperty(key)
+            } else {
+                System.setProperty(key, value)
+            }
+        }
+    }
+
+    @Nested
+    inner class InlineDependencyVersionsTests {
+
+        private fun pomWithDependency(groupId: String, artifactId: String, version: String? = null): Node {
+            val root = Node(null, "project")
+            val deps = root.appendNode("dependencies")
+            val dep = deps.appendNode("dependency")
+            dep.appendNode("groupId", groupId)
+            dep.appendNode("artifactId", artifactId)
+            if (version != null) {
+                dep.appendNode("version", version)
+            }
+            return root
+        }
+
+        private fun Node.appendDependencyManagement(vararg entries: Triple<String, String, String>): Node {
+            val mgmt = appendNode("dependencyManagement")
+            val deps = mgmt.appendNode("dependencies")
+            entries.forEach { (groupId, artifactId, version) ->
+                val dep = deps.appendNode("dependency")
+                dep.appendNode("groupId", groupId)
+                dep.appendNode("artifactId", artifactId)
+                dep.appendNode("version", version)
+            }
+            return mgmt
+        }
+
+        private fun dependencyVersion(root: Node, artifactId: String): String? {
+            val deps = (root.get("dependencies") as groovy.util.NodeList).firstOrNull() as Node? ?: return null
+            return deps.children().filterIsInstance<Node>()
+                .firstOrNull { dep ->
+                    dep.children().filterIsInstance<Node>()
+                        .any { it.name() == "artifactId" && it.text() == artifactId }
+                }
+                ?.children()?.filterIsInstance<Node>()
+                ?.firstOrNull { it.name() == "version" }?.text()
+        }
+
+        private fun hasDependencyManagement(root: Node): Boolean =
+            (root.get("dependencyManagement") as groovy.util.NodeList).isNotEmpty()
+
+        @Test
+        fun `should inline version from dependencyManagement and remove the section`() {
+            val root = pomWithDependency("io.komune", "lib-a")
+            root.appendDependencyManagement(Triple("io.komune", "lib-a", "2.0.0"))
+
+            inlineDependencyVersions(root)
+
+            assertThat(dependencyVersion(root, "lib-a")).isEqualTo("2.0.0")
+            assertThat(hasDependencyManagement(root)).isFalse()
+        }
+
+        @Test
+        fun `should keep explicit dependency versions untouched`() {
+            val root = pomWithDependency("io.komune", "lib-a", "1.5.0")
+            root.appendDependencyManagement(Triple("io.komune", "lib-a", "2.0.0"))
+
+            inlineDependencyVersions(root)
+
+            assertThat(dependencyVersion(root, "lib-a")).isEqualTo("1.5.0")
+        }
+
+        @Test
+        fun `should fall back to resolved versions when dependencyManagement has no entry`() {
+            val root = pomWithDependency("io.komune", "lib-b")
+
+            inlineDependencyVersions(root, mapOf("io.komune:lib-b" to "3.1.0"))
+
+            assertThat(dependencyVersion(root, "lib-b")).isEqualTo("3.1.0")
+        }
+
+        @Test
+        fun `should prefer dependencyManagement version over resolved version`() {
+            val root = pomWithDependency("io.komune", "lib-a")
+            root.appendDependencyManagement(Triple("io.komune", "lib-a", "2.0.0"))
+
+            inlineDependencyVersions(root, mapOf("io.komune:lib-a" to "9.9.9"))
+
+            assertThat(dependencyVersion(root, "lib-a")).isEqualTo("2.0.0")
+        }
+
+        @Test
+        fun `should ignore BOM imports in dependencyManagement`() {
+            val root = pomWithDependency("io.komune", "lib-a")
+            val mgmt = root.appendNode("dependencyManagement")
+            val deps = mgmt.appendNode("dependencies")
+            val bom = deps.appendNode("dependency")
+            bom.appendNode("groupId", "io.komune")
+            bom.appendNode("artifactId", "lib-a")
+            bom.appendNode("version", "1.0.0")
+            bom.appendNode("scope", "import")
+
+            inlineDependencyVersions(root)
+
+            assertThat(dependencyVersion(root, "lib-a")).isNull()
+            assertThat(hasDependencyManagement(root)).isFalse()
+        }
+
+        @Test
+        fun `should leave dependency without any known version untouched`() {
+            val root = pomWithDependency("io.komune", "lib-unknown")
+
+            inlineDependencyVersions(root, mapOf("io.komune:other" to "1.0.0"))
+
+            assertThat(dependencyVersion(root, "lib-unknown")).isNull()
+        }
+
+        @Test
+        fun `should handle pom without dependencies section`() {
+            val root = Node(null, "project")
+            root.appendDependencyManagement(Triple("io.komune", "lib-a", "2.0.0"))
+
+            inlineDependencyVersions(root)
+
+            assertThat(hasDependencyManagement(root)).isFalse()
+        }
+
+        @Test
+        fun `should handle namespaced node names`() {
+            val root = Node(null, "{http://maven.apache.org/POM/4.0.0}project")
+            val deps = root.appendNode("{http://maven.apache.org/POM/4.0.0}dependencies")
+            val dep = deps.appendNode("{http://maven.apache.org/POM/4.0.0}dependency")
+            dep.appendNode("{http://maven.apache.org/POM/4.0.0}groupId", "io.komune")
+            dep.appendNode("{http://maven.apache.org/POM/4.0.0}artifactId", "lib-a")
+
+            inlineDependencyVersions(root, mapOf("io.komune:lib-a" to "4.0.0"))
+
+            val version = dep.children().filterIsInstance<Node>()
+                .firstOrNull { it.name().toString().endsWith("version") }
+            assertThat(version?.text()).isEqualTo("4.0.0")
+        }
+    }
+}

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPluginUploadTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPluginUploadTest.kt
@@ -1,0 +1,167 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import com.sun.net.httpserver.HttpServer
+import io.komune.fixers.gradle.config.ConfigExtension
+import java.io.File
+import java.net.InetSocketAddress
+import java.util.concurrent.ConcurrentLinkedQueue
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the PublishPlugin stage/promote upload actions,
+ * executed against a local HTTP server.
+ */
+class PublishPluginUploadTest {
+
+    private lateinit var server: HttpServer
+    private val requests = ConcurrentLinkedQueue<String>()
+
+    @BeforeEach
+    fun startServer() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        server.createContext("/") { exchange ->
+            requests.add("${exchange.requestMethod} ${exchange.requestURI}")
+            exchange.requestBody.readBytes()
+            val response = "ok".toByteArray()
+            exchange.sendResponseHeaders(200, response.size.toLong())
+            exchange.responseBody.use { it.write(response) }
+        }
+        server.start()
+    }
+
+    @AfterEach
+    fun stopServer() {
+        server.stop(0)
+    }
+
+    private fun baseUrl() = "http://localhost:${server.address.port}"
+
+    private fun evaluatedBuild(
+        version: String,
+        configure: (ConfigExtension) -> Unit = {}
+    ): Project {
+        val root = ProjectBuilder.builder().build()
+        root.version = version
+        val config = root.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, root)
+        configure(config)
+        val child = ProjectBuilder.builder().withParent(root).withName("lib").build()
+        child.pluginManager.apply("io.komune.fixers.gradle.publish")
+        root.plugins.apply(PublishPlugin::class.java)
+        (child as ProjectInternal).evaluate()
+        val gradle = root.gradle as GradleInternal
+        gradle.buildListenerBroadcaster.projectsEvaluated(gradle)
+        return root
+    }
+
+    private fun Project.stagingDir(): File {
+        val dir = layout.buildDirectory.dir("staging-deploy").get().asFile
+        dir.mkdirs()
+        return dir
+    }
+
+    private fun Task.executeActions() {
+        actions.forEach { it.execute(this) }
+    }
+
+    @Test
+    fun `cleanStaging should delete the staging directory`() {
+        val root = evaluatedBuild("1.0.0")
+        val staging = root.stagingDir()
+        File(staging, "artifact.jar").writeText("bytes")
+
+        root.tasks.getByName("cleanStaging").executeActions()
+
+        assertThat(staging).doesNotExist()
+    }
+
+    @Test
+    fun `stage should upload staging files to github packages`() {
+        val root = evaluatedBuild("1.0.0") { config ->
+            config.publish.pkgGithubUsername.set("gh-user")
+            config.publish.pkgGithubToken.set("gh-token")
+            config.publish.githubPackagesUrl.set("${baseUrl()}/maven")
+        }
+        File(root.stagingDir(), "io/komune/lib/1.0.0/lib-1.0.0.jar").apply {
+            parentFile.mkdirs()
+            writeText("bytes")
+        }
+
+        root.tasks.getByName("stage").executeActions()
+
+        assertThat(requests).contains("PUT /maven/io/komune/lib/1.0.0/lib-1.0.0.jar")
+    }
+
+    @Test
+    fun `stage should fail when github credentials are missing`() {
+        val root = evaluatedBuild("1.0.0")
+        File(root.stagingDir(), "artifact.jar").writeText("bytes")
+
+        assertThatThrownBy { root.tasks.getByName("stage").executeActions() }
+            .isInstanceOf(GradleException::class.java)
+            .hasMessageContaining("FIXERS_PUBLISH_GITHUB_USERNAME")
+    }
+
+    @Test
+    fun `promote should upload snapshots to maven snapshots repository`() {
+        val root = evaluatedBuild("1.0.0-SNAPSHOT") { config ->
+            config.publish.mavenCentralUsername.set("central-user")
+            config.publish.mavenCentralPassword.set("central-pass")
+            config.publish.mavenSnapshotsUrl.set("${baseUrl()}/snapshots")
+        }
+        File(root.stagingDir(), "io/komune/lib/lib.jar").apply {
+            parentFile.mkdirs()
+            writeText("bytes")
+        }
+
+        root.tasks.getByName("promote").executeActions()
+
+        assertThat(requests).contains("PUT /snapshots/io/komune/lib/lib.jar")
+    }
+
+    @Test
+    fun `promote should fail for snapshots when credentials are missing`() {
+        val root = evaluatedBuild("1.0.0-SNAPSHOT")
+        File(root.stagingDir(), "artifact.jar").writeText("bytes")
+
+        assertThatThrownBy { root.tasks.getByName("promote").executeActions() }
+            .isInstanceOf(GradleException::class.java)
+            .hasMessageContaining("FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME")
+    }
+
+    @Test
+    fun `promote should upload release bundle to central portal`() {
+        val root = evaluatedBuild("1.0.0") { config ->
+            config.publish.mavenCentralUsername.set("central-user")
+            config.publish.mavenCentralPassword.set("central-pass")
+            config.publish.mavenCentralUrl.set(baseUrl())
+        }
+        File(root.stagingDir(), "io/komune/lib/lib.jar").apply {
+            parentFile.mkdirs()
+            writeText("bytes")
+        }
+
+        root.tasks.getByName("promote").executeActions()
+
+        assertThat(requests).anyMatch { it.startsWith("POST /upload?publishingType=AUTOMATIC") }
+    }
+
+    @Test
+    fun `promote should fail for releases when credentials are missing`() {
+        val root = evaluatedBuild("1.0.0")
+        File(root.stagingDir(), "artifact.jar").writeText("bytes")
+
+        assertThatThrownBy { root.tasks.getByName("promote").executeActions() }
+            .isInstanceOf(GradleException::class.java)
+            .hasMessageContaining("FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME")
+    }
+}


### PR DESCRIPTION
## SonarQube cleanup — coverage 34% → 92%

### Fixes
- `kotlin:S1135`: reworded TODO in `PublishMppSetup` into a rationale comment for the gradle/gradle#26091 signing-ordering workaround (only open Sonar issue)

### Tests (~245 total, local JaCoCo line coverage 34% → 92.0%)
- PublishPlugin end-to-end wiring (repos, signing, stage/promote/cleanStaging tasks, portal credential bridge, POM version inlining, upload actions against a local HttpServer)
- All publish setups (Jvm/Mpp/Platform/Catalog/GradleModule), PomUtils, CentralPortalUploader, DefaultHttpPutClient
- JvmPlugin, MppPlugin, MppJsPlugin, ConfigPlugin, kt2Ts cleaning, PropertyUtils (env-priority), NpmPlugin, DetektConfiguration, CheckPlugin lifecycle, JacocoConfigurator, DependenciesPlugin, config models, composite script plugins

### Hardening
- Test task now scrubs ambient `FIXERS_*` env vars — real release credentials from the shell were leaking into tests — and injects controlled test vars

Remaining gaps: inline-function attribution (JaCoCo limitation), dead `whenPluginAdded` block, `collectResolvedVersions` (only reachable during real POM generation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage across configuration, publishing, Kotlin, npm, dependency, quality-check, and project lifecycle features.
  * Added validation for publishing uploads, authentication, staging behavior, generated metadata, and error handling.
  * Added coverage for environment-based settings, defaults, overrides, report configuration, and cross-project behavior.
* **Documentation**
  * Clarified publishing task ordering requirements for signing and publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->