### PR TITLE
chore(deps): batch-update dependabot version bumps

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -168,7 +168,7 @@ jobs:
       FIXERS_PUBLISH_GRADLE_PORTAL_SECRET: ${{ secrets.FIXERS_PUBLISH_GRADLE_PORTAL_SECRET }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Full history so the Sonar Gradle scanner can blame files and detect
           # new code against the target branch during pull request analysis.

--- a/.github/workflows/make-kotlin-npm-workflow.yml
+++ b/.github/workflows/make-kotlin-npm-workflow.yml
@@ -111,7 +111,7 @@ jobs:
       FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
       FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Initialize Java and Gradle Environment
         uses: komune-io/fixers-gradle/.github/actions/jvm@main
         with:

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -137,7 +137,7 @@ jobs:
     env:
       FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -167,7 +167,7 @@ jobs:
       FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Mise
         uses: jdx/mise-action@v4

--- a/.github/workflows/mise-kotlin-npm-workflow.yml
+++ b/.github/workflows/mise-kotlin-npm-workflow.yml
@@ -88,7 +88,7 @@ jobs:
       FIXERS_PUBLISH_GITHUB_USERNAME: ${{ secrets.FIXERS_PUBLISH_GITHUB_USERNAME }}
       FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.FIXERS_PUBLISH_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Mise
         uses: jdx/mise-action@v4

--- a/.github/workflows/mise-nodejs-workflow.yml
+++ b/.github/workflows/mise-nodejs-workflow.yml
@@ -131,7 +131,7 @@ jobs:
     env:
       FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -104,7 +104,7 @@ jobs:
     name: Publish to Chromatic
     needs: [package-storybook]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Initialize Node.js
@@ -129,7 +129,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Initialize Node.js for GitHub Pages

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -36,7 +36,7 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.SOURCE_BRANCH }}
           submodules: true

--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -44,7 +44,7 @@ jobs:
       FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
       FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Initialize Java and Gradle Environment
@@ -76,7 +76,7 @@ jobs:
       FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
       FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Initialize Java and Gradle Environment
@@ -117,7 +117,7 @@ jobs:
 #      contents: read
 #      security-events: write
 #    steps:
-#      - uses: actions/checkout@v6
+#      - uses: actions/checkout@v7
 #      - name: Run Codacy Analysis
 #        uses: codacy/codacy-analysis-cli-action@v4
 #        with:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 detekt = "2.0.0-alpha.5"
-kotlin = "2.2.20"
+kotlin = "2.4.10"
 sonarQube = "7.3.1.8318"
 npmPublish = "3.5.3"
 gradlePublish = "2.1.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-detekt = "2.0.0-alpha.5"
+detekt = "2.0.0-alpha.6"
 kotlin = "2.4.10"
 sonarQube = "7.3.1.8318"
 npmPublish = "3.5.3"
 gradlePublish = "2.1.1"
-junit-jupiter = "6.1.1"
+junit-jupiter = "6.1.2"
 assertj = "3.27.7"
 mockito = "5.23.0"
 mockito-kotlin = "6.3.0"
 commons-lang3 = "3.20.0"
 coroutines = "1.11.0"
-jacoco = "0.8.14"
+jacoco = "0.8.15"
 
 [libraries]
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-detekt = "2.0.0-alpha.3"
+detekt = "2.0.0-alpha.5"
 kotlin = "2.2.20"
-sonarQube = "7.3.0.8198"
+sonarQube = "7.3.1.8318"
 npmPublish = "3.5.3"
 gradlePublish = "2.1.1"
 junit-jupiter = "6.1.1"


### PR DESCRIPTION
## Summary
Consolidates the pending Dependabot PRs, plus a couple more found stale while auditing the full catalog:
- #171: `org.jetbrains.kotlin:kotlin-gradle-plugin` 2.2.20 -> 2.4.10
- #172: `org.sonarsource.scanner.gradle:sonarqube-gradle-plugin` 7.3.0.8198 -> 7.3.1.8318
- #174: `actions/checkout` 6 -> 7
- #176: `dev.detekt:detekt-gradle-plugin` 2.0.0-alpha.3 -> 2.0.0-alpha.6 (alpha.5 via #176, alpha.6 found newer during audit)
- `junit-jupiter` 6.1.1 -> 6.1.2 (no open Dependabot PR yet)
- `jacoco` 0.8.14 -> 0.8.15 (no open Dependabot PR yet)

Full catalog audited against Maven Central / Gradle Plugin Portal `maven-metadata.xml` — everything else (`npmPublish`, `gradlePublish`, `assertj`, `mockito`, `mockito-kotlin`, `commons-lang3`, `coroutines`) is already at the latest stable release.

Note on kotlin-gradle-plugin: `kotlin` in `gradle/libs.versions.toml` is only consumed by `plugin/build.gradle.kts` (`libs.kotlinGradlePlugin`) and, via `getKotlinPluginVersion()` in `JvmPlugin.kt`/`MppPlugin.kt`, sets the default Kotlin `languageVersion` applied to every consumer of `io.komune.fixers.gradle.kotlin.jvm`/`.mpp`. It is not tied to Gradle's own embedded Kotlin version (Gradle 9.6.0 embeds 2.3.21 independently, used directly via `embeddedKotlinVersion` for this repo's own build). Bumping it changes that consumer default from 2.2 to 2.4.

## Test plan
- [x] `./gradlew build` (full build + tests, all bumps combined) passes locally