### PR TITLE
feat: generic skip-tasks mechanism for make/mise workflows; fix dependency-submission on Dependabot PRs

### DIFF
--- a/.github/actions/make-step-optional/action.yml
+++ b/.github/actions/make-step-optional/action.yml
@@ -9,6 +9,10 @@ inputs:
   make-step:
     description: 'The make step to conditionally execute'
     required: true
+  skip:
+    description: "Set to 'true' to skip this step entirely, even if it exists in the Makefile."
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -27,7 +31,7 @@ runs:
       shell: bash
 
     - name: Run ${{ inputs.make-step }}
-      if: ${{ steps.check_step.outputs.exists == 'true' }}
+      if: ${{ steps.check_step.outputs.exists == 'true' && inputs.skip != 'true' }}
       env:
         MAKE_FILE: ${{ inputs.make-file }}
         MAKE_STEP: ${{ inputs.make-step }}

--- a/.github/actions/make-step-prepost/action.yml
+++ b/.github/actions/make-step-prepost/action.yml
@@ -8,6 +8,10 @@ inputs:
   make-step:
     description: "The base make step to execute along with its optional pre and post steps"
     required: true
+  skip:
+    description: "Set to 'true' to skip the step and its pre/post steps entirely."
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -17,15 +21,18 @@ runs:
       with:
         make-file: ${{ inputs.make-file }}
         make-step: ${{ inputs.make-step }}-pre
+        skip: ${{ inputs.skip }}
 
     - name: Run ${{ inputs.make-step }} optionally
       uses: komune-io/fixers-gradle/.github/actions/make-step-optional@main
       with:
         make-file: ${{ inputs.make-file }}
         make-step: ${{ inputs.make-step }}
+        skip: ${{ inputs.skip }}
 
     - name: Run ${{ inputs.make-step }}-post optionally
       uses: komune-io/fixers-gradle/.github/actions/make-step-optional@main
       with:
         make-file: ${{ inputs.make-file }}
         make-step: ${{ inputs.make-step }}-post
+        skip: ${{ inputs.skip }}

--- a/.github/actions/mise-step-optional/action.yml
+++ b/.github/actions/mise-step-optional/action.yml
@@ -4,6 +4,10 @@ inputs:
   mise-task:
     description: 'The mise task to conditionally execute'
     required: true
+  skip:
+    description: "Set to 'true' to skip this step entirely, even if the task exists."
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -21,7 +25,7 @@ runs:
       shell: bash
 
     - name: Run ${{ inputs.mise-task }}
-      if: ${{ steps.check_step.outputs.exists == 'true' }}
+      if: ${{ steps.check_step.outputs.exists == 'true' && inputs.skip != 'true' }}
       env:
         MISE_TASK: ${{ inputs.mise-task }}
       run: |

--- a/.github/actions/mise-step-prepost/action.yml
+++ b/.github/actions/mise-step-prepost/action.yml
@@ -4,6 +4,10 @@ inputs:
   mise-task:
     description: "The base mise task to execute along with its optional pre and post tasks"
     required: true
+  skip:
+    description: "Set to 'true' to skip the task and its pre/post tasks entirely."
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -12,13 +16,16 @@ runs:
       uses: komune-io/fixers-gradle/.github/actions/mise-step-optional@main
       with:
         mise-task: ${{ inputs.mise-task }}:pre
+        skip: ${{ inputs.skip }}
 
     - name: Run ${{ inputs.mise-task }} optionally
       uses: komune-io/fixers-gradle/.github/actions/mise-step-optional@main
       with:
         mise-task: ${{ inputs.mise-task }}
+        skip: ${{ inputs.skip }}
 
     - name: Run ${{ inputs.mise-task }}:post optionally
       uses: komune-io/fixers-gradle/.github/actions/mise-step-optional@main
       with:
         mise-task: ${{ inputs.mise-task }}:post
+        skip: ${{ inputs.skip }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -232,7 +232,10 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
       - name: Execute Make Check Task
-        if: (contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
+        # Skip whenever FIXERS_SONAR_TOKEN is unavailable (e.g. Dependabot PRs,
+        # fork PRs, or repos that haven't configured Sonar) — GitHub withholds
+        # repo secrets from those workflow runs, so `sonar` would just fail auth.
+        if: secrets.FIXERS_SONAR_TOKEN != '' && ((contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/')))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -69,6 +69,12 @@ on:
         type: "string"
         default: "check"
 
+      skip-check-task:
+        description: "Set to 'true' to skip the check task entirely, e.g. when the caller knows a secret it needs (like a Sonar token) is unavailable for this run."
+        required: false
+        type: "string"
+        default: "false"
+
       make-promote-task:
         description: "The Make command to execute for promote."
         required: false
@@ -232,7 +238,7 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
       - name: Execute Make Check Task
-        if: (contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
+        if: inputs.skip-check-task != 'true' && ((contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/')))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -69,11 +69,11 @@ on:
         type: "string"
         default: "check"
 
-      skip-check-task:
-        description: "Set to 'true' to skip the check task entirely, e.g. when the caller knows a secret it needs (like a Sonar token) is unavailable for this run."
+      skip-tasks:
+        description: "Comma-separated list of task names (matching the values of the make-*-task inputs, e.g. 'check' or 'check,promote') to skip entirely for this run — e.g. when a caller knows a task's secret dependency is unavailable."
         required: false
         type: "string"
-        default: "false"
+        default: ""
 
       make-promote-task:
         description: "The Make command to execute for promote."
@@ -198,6 +198,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-lint-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.make-lint-task) }}
 
       - name: Setup Docker Buildx for Specified Platforms
         if: inputs.docker-buildx-platform != ''
@@ -210,6 +211,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-build-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.make-build-task) }}
 
       - name: Execute Make Test Task
         if: (contains(inputs.on-tag, inputs.make-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
@@ -217,6 +219,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-test-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.make-test-task) }}
 
       - name: Upload Analysis Reports
         uses: komune-io/fixers-gradle/.github/actions/upload-analysis-reports@main
@@ -237,13 +240,14 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.make-stage-task) }}
       - name: Execute Make Check Task
         if: (contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-check-task }}
-          skip: ${{ inputs.skip-check-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.make-check-task) }}
 
       - name: Docker Registry Login To Promote
         if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) ))
@@ -259,6 +263,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-promote-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.make-promote-task) }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -69,12 +69,6 @@ on:
         type: "string"
         default: "check"
 
-      skip-check-task:
-        description: "Set to 'true' to skip the check task entirely, e.g. when the caller knows a secret it needs (like a Sonar token) is unavailable for this run."
-        required: false
-        type: "string"
-        default: "false"
-
       make-promote-task:
         description: "The Make command to execute for promote."
         required: false
@@ -238,7 +232,7 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
       - name: Execute Make Check Task
-        if: inputs.skip-check-task != 'true' && ((contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/')))
+        if: (contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -69,6 +69,12 @@ on:
         type: "string"
         default: "check"
 
+      skip-check-task:
+        description: "Set to 'true' to skip the check task entirely, e.g. when the caller knows a secret it needs (like a Sonar token) is unavailable for this run."
+        required: false
+        type: "string"
+        default: "false"
+
       make-promote-task:
         description: "The Make command to execute for promote."
         required: false
@@ -237,6 +243,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-check-task }}
+          skip: ${{ inputs.skip-check-task }}
 
       - name: Docker Registry Login To Promote
         if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) ))

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -232,10 +232,7 @@ jobs:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
       - name: Execute Make Check Task
-        # Skip whenever FIXERS_SONAR_TOKEN is unavailable (e.g. Dependabot PRs,
-        # fork PRs, or repos that haven't configured Sonar) — GitHub withholds
-        # repo secrets from those workflow runs, so `sonar` would just fail auth.
-        if: secrets.FIXERS_SONAR_TOKEN != '' && ((contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/')))
+        if: (contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -63,11 +63,11 @@ on:
         type: "string"
         default: "check"
 
-      skip-check-task:
-        description: "Set to 'true' to skip the check task entirely, e.g. when the caller knows a secret it needs (like a Sonar token) is unavailable for this run."
+      skip-tasks:
+        description: "Comma-separated list of task names (matching the values of the mise-*-task inputs, e.g. 'check' or 'check,promote') to skip entirely for this run — e.g. when a caller knows a task's secret dependency is unavailable."
         required: false
         type: "string"
-        default: "false"
+        default: ""
 
       mise-promote-task:
         description: "The mise task to execute for promote."
@@ -195,6 +195,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-lint-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-lint-task) }}
 
       - name: Setup Docker Buildx for Specified Platforms
         if: inputs.docker-buildx-platform != ''
@@ -206,12 +207,14 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-build-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-build-task) }}
 
       - name: Execute Mise Test Task
         if: (contains(inputs.on-tag, inputs.mise-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-test-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-test-task) }}
 
       - name: Upload Analysis Reports
         uses: komune-io/fixers-gradle/.github/actions/upload-analysis-reports@main
@@ -231,13 +234,14 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-stage-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-stage-task) }}
 
       - name: Execute Mise Check Task
         if: (contains(inputs.on-tag, inputs.mise-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}
-          skip: ${{ inputs.skip-check-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-check-task) }}
 
       - name: Docker Registry Login To Promote
         if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) ))
@@ -252,6 +256,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-promote-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-promote-task) }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -63,6 +63,12 @@ on:
         type: "string"
         default: "check"
 
+      skip-check-task:
+        description: "Set to 'true' to skip the check task entirely, e.g. when the caller knows a secret it needs (like a Sonar token) is unavailable for this run."
+        required: false
+        type: "string"
+        default: "false"
+
       mise-promote-task:
         description: "The mise task to execute for promote."
         required: false
@@ -231,6 +237,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}
+          skip: ${{ inputs.skip-check-task }}
 
       - name: Docker Registry Login To Promote
         if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) ))

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -227,7 +227,10 @@ jobs:
           mise-task: ${{ inputs.mise-stage-task }}
 
       - name: Execute Mise Check Task
-        if: (contains(inputs.on-tag, inputs.mise-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
+        # Skip whenever FIXERS_SONAR_TOKEN is unavailable (e.g. Dependabot PRs,
+        # fork PRs, or repos that haven't configured Sonar) — GitHub withholds
+        # repo secrets from those workflow runs, so `sonar` would just fail auth.
+        if: secrets.FIXERS_SONAR_TOKEN != '' && ((contains(inputs.on-tag, inputs.mise-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/')))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -227,10 +227,7 @@ jobs:
           mise-task: ${{ inputs.mise-stage-task }}
 
       - name: Execute Mise Check Task
-        # Skip whenever FIXERS_SONAR_TOKEN is unavailable (e.g. Dependabot PRs,
-        # fork PRs, or repos that haven't configured Sonar) — GitHub withholds
-        # repo secrets from those workflow runs, so `sonar` would just fail auth.
-        if: secrets.FIXERS_SONAR_TOKEN != '' && ((contains(inputs.on-tag, inputs.mise-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/')))
+        if: (contains(inputs.on-tag, inputs.mise-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}

--- a/.github/workflows/mise-kotlin-npm-workflow.yml
+++ b/.github/workflows/mise-kotlin-npm-workflow.yml
@@ -51,6 +51,12 @@ on:
         type: "string"
         default: "promote"
 
+      skip-tasks:
+        description: "Comma-separated list of task names (matching the values of the mise-*-task inputs, e.g. 'check' or 'check,promote') to skip entirely for this run — e.g. when a caller knows a task's secret dependency is unavailable."
+        required: false
+        type: "string"
+        default: ""
+
       artifact-name:
         description: "The name for the uploaded artifact, if needed."
         required: false
@@ -112,23 +118,27 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-lint-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-lint-task) }}
 
       - name: Execute Mise Build Task
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-build-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-build-task) }}
 
       - name: Execute Mise Test Task
         if: (contains(inputs.on-tag, inputs.mise-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-test-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-test-task) }}
 
       - name: Execute Mise Stage Task
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-stage-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-stage-task) }}
         env:
           FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -137,12 +147,14 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-check-task) }}
 
       - name: Execute Mise Promote Task
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-promote-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-promote-task) }}
         env:
           FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
 

--- a/.github/workflows/mise-nodejs-workflow.yml
+++ b/.github/workflows/mise-nodejs-workflow.yml
@@ -79,6 +79,12 @@ on:
         type: "string"
         default: "promote"
 
+      skip-tasks:
+        description: "Comma-separated list of task names (matching the values of the mise-*-task inputs, e.g. 'check' or 'check,promote') to skip entirely for this run — e.g. when a caller knows a task's secret dependency is unavailable."
+        required: false
+        type: "string"
+        default: ""
+
       docker-stage-repository:
         description: "The Docker registry to which images should be staged. Defaults to GitHub Container Registry (ghcr.io)."
         required: false
@@ -164,6 +170,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-lint-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-lint-task) }}
 
       - if: inputs.docker-buildx-platform != ''
         name: Setup Docker Buildx for Specified Platforms
@@ -175,12 +182,14 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-build-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-build-task) }}
 
       - name: Execute Mise Test Task
         if: (contains(inputs.on-tag, inputs.mise-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-test-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-test-task) }}
 
       - if: inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage')))
         name: Docker Registry Login to Stage
@@ -195,6 +204,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-stage-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-stage-task) }}
 
       - if: inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')))
         name: Docker Registry Login To Promote
@@ -217,12 +227,14 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-check-task) }}
 
       - name: Execute Mise Promote Task
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-promote-task }}
+          skip: ${{ contains(inputs.skip-tasks, inputs.mise-promote-task) }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -99,7 +99,10 @@ jobs:
       DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_PROMOTE_PASSWORD }}
 
   publish-chromatic:
-    if: inputs.with-chromatic
+    # Also skip when FIXERS_CHROMATIC_PROJECT_TOKEN is unavailable (e.g.
+    # Dependabot PRs, fork PRs) — GitHub withholds repo secrets from those
+    # workflow runs, so the Chromatic publish step below would just fail auth.
+    if: inputs.with-chromatic && secrets.FIXERS_CHROMATIC_PROJECT_TOKEN != ''
     runs-on: ubuntu-latest
     name: Publish to Chromatic
     needs: [package-storybook]

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -99,10 +99,7 @@ jobs:
       DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_PROMOTE_PASSWORD }}
 
   publish-chromatic:
-    # Also skip when FIXERS_CHROMATIC_PROJECT_TOKEN is unavailable (e.g.
-    # Dependabot PRs, fork PRs) — GitHub withholds repo secrets from those
-    # workflow runs, so the Chromatic publish step below would just fail auth.
-    if: inputs.with-chromatic && secrets.FIXERS_CHROMATIC_PROJECT_TOKEN != ''
+    if: inputs.with-chromatic
     runs-on: ubuntu-latest
     name: Publish to Chromatic
     needs: [package-storybook]

--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -59,6 +59,10 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v6
       - name: Submit Dependency Graph
+        # Dependabot-triggered pull_request runs always get a read-only
+        # GITHUB_TOKEN regardless of the `permissions:` block above, so this
+        # write-requiring step would fail auth on those PRs. Skip it there.
+        if: github.actor != 'dependabot[bot]'
         uses: gradle/actions/dependency-submission@v6
         with:
           additional-arguments: -I ${{ steps.jvm.outputs.setup_gradle_github_pkg }} --no-configuration-cache
@@ -67,7 +71,10 @@ jobs:
           build-scan-terms-of-use-agree: "yes"
 
   sonarcloud-analysis:
-    if: ${{ inputs.with-sonarcloud }}
+    # Also skip when FIXERS_SONAR_TOKEN is unavailable (e.g. Dependabot PRs,
+    # fork PRs) — GitHub withholds repo secrets from those workflow runs, so
+    # the Sonar scan/quality-gate steps below would just fail auth.
+    if: ${{ inputs.with-sonarcloud && secrets.FIXERS_SONAR_TOKEN != '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -71,10 +71,7 @@ jobs:
           build-scan-terms-of-use-agree: "yes"
 
   sonarcloud-analysis:
-    # Also skip when FIXERS_SONAR_TOKEN is unavailable (e.g. Dependabot PRs,
-    # fork PRs) — GitHub withholds repo secrets from those workflow runs, so
-    # the Sonar scan/quality-gate steps below would just fail auth.
-    if: ${{ inputs.with-sonarcloud && secrets.FIXERS_SONAR_TOKEN != '' }}
+    if: ${{ inputs.with-sonarcloud }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Found while diagnosing komune-io/fixers-f2#121 (Dependabot PR failing CI on `./gradlew sonar`: "Not authorized or project not found").
- Root cause: GitHub withholds repo secrets, and forces a read-only `GITHUB_TOKEN`, on Dependabot-triggered `pull_request` runs. Not configurable, no per-secret allowlist.
- `sec-workflow.yml`'s `gradle-dependency-analysis` job runs `gradle/actions/dependency-submission@v6`, which needs `contents: write` — fails on Dependabot PRs for the same underlying reason (token permission downgrade).
- The Sonar-check failure itself needs a per-repo fix (only the calling repo knows whether its `check` target depends on a secret), so it isn't fixed generically here — but this PR adds the mechanism that fix will use.

## Changes
- `make-step-optional` / `make-step-prepost` / `mise-step-optional` / `mise-step-prepost`: add a `skip` input. Skips the step/task entirely when `'true'`, regardless of whether it exists in the Makefile/mise config.
- `make-jvm-workflow.yml`, `mise-jvm-workflow.yml`, `mise-nodejs-workflow.yml`, `mise-kotlin-npm-workflow.yml`: add a single `skip-tasks` input — comma-separated task names to skip (same pattern already used by `on-tag`) — wired into every task step via `contains(inputs.skip-tasks, inputs.make-*-task)` / `contains(inputs.skip-tasks, inputs.mise-*-task)`. One input covers every task, present and future, rather than a dedicated `skip-check-task`/`skip-lint-task`/etc. per task.
- `sec-workflow.yml`: skip the dependency-submission step when the actor is `dependabot[bot]` (actor-gated, not secret-gated — applies universally regardless of what a given repo's check does).

## Test plan
- [ ] Confirm a Dependabot PR against a consumer repo (fixers-c2, fixers-s2, or fixers-d2, which call `sec-workflow.yml`) no longer fails on the dependency-submission step once this merges.
- [ ] Confirm a normal (non-Dependabot) PR still submits the dependency graph and runs check/lint/build/test as before.
- [ ] fixers-f2 follow-up: wire `skip-tasks: ${{ github.actor == 'dependabot[bot]' && 'check' || '' }}` into its `dev.yml` once this merges to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional task-skipping controls to reusable build workflows.
  * Callers can provide comma-separated task names to skip selected lint, build, test, staging, checking, or promotion steps.
  * Skip controls apply consistently across Make and Mise workflows, including pre- and post-task actions.

* **Bug Fixes**
  * Dependency graph submissions no longer run for Dependabot pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->