### PR TITLE
fix: exact-token skip-tasks matching, gate login steps on skip

### DIFF
--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -198,7 +198,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-lint-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.make-lint-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-lint-task)) }}
 
       - name: Setup Docker Buildx for Specified Platforms
         if: inputs.docker-buildx-platform != ''
@@ -211,7 +211,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-build-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.make-build-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-build-task)) }}
 
       - name: Execute Make Test Task
         if: (contains(inputs.on-tag, inputs.make-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
@@ -219,7 +219,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-test-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.make-test-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-test-task)) }}
 
       - name: Upload Analysis Reports
         uses: komune-io/fixers-gradle/.github/actions/upload-analysis-reports@main
@@ -227,7 +227,7 @@ jobs:
           make-file: ${{ inputs.make-file }}
 
       - name: Docker Registry Login to Stage
-        if: (inputs.force-stage == 'true' || (inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' ||startsWith(github.ref, 'refs/heads/release/') ||startsWith(github.ref, 'refs/heads/versioning/') ||(contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/'))) ||(github.event_name == 'pull_request' &&(contains(github.event.pull_request.labels.*.name, 'stage') || startsWith(github.head_ref, 'versioning/'))))))
+        if: (inputs.force-stage == 'true' || (inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' ||startsWith(github.ref, 'refs/heads/release/') ||startsWith(github.ref, 'refs/heads/versioning/') ||(contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/'))) ||(github.event_name == 'pull_request' &&(contains(github.event.pull_request.labels.*.name, 'stage') || startsWith(github.head_ref, 'versioning/')))))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-stage-task))
         uses: docker/login-action@v4.5.2
         with:
           registry: ${{ inputs.docker-stage-repository }}
@@ -240,17 +240,17 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.make-stage-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-stage-task)) }}
       - name: Execute Make Check Task
         if: (contains(inputs.on-tag, inputs.make-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/make-step-prepost@main
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-check-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.make-check-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-check-task)) }}
 
       - name: Docker Registry Login To Promote
-        if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) ))
+        if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) )) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-promote-task))
         uses: docker/login-action@v4.5.2
         with:
           registry: ${{ inputs.docker-promote-repository }}
@@ -263,7 +263,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-promote-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.make-promote-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-promote-task)) }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -195,7 +195,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-lint-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-lint-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-lint-task)) }}
 
       - name: Setup Docker Buildx for Specified Platforms
         if: inputs.docker-buildx-platform != ''
@@ -207,14 +207,14 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-build-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-build-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-build-task)) }}
 
       - name: Execute Mise Test Task
         if: (contains(inputs.on-tag, inputs.mise-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-test-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-test-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-test-task)) }}
 
       - name: Upload Analysis Reports
         uses: komune-io/fixers-gradle/.github/actions/upload-analysis-reports@main
@@ -222,7 +222,7 @@ jobs:
           artifact-name: ${{ inputs.analysis-reports-name }}
 
       - name: Docker Registry Login to Stage
-        if: (inputs.force-stage == 'true' || (inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' ||startsWith(github.ref, 'refs/heads/release/') ||startsWith(github.ref, 'refs/heads/versioning/') ||(contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/'))) ||(github.event_name == 'pull_request' &&(contains(github.event.pull_request.labels.*.name, 'stage') || startsWith(github.head_ref, 'versioning/'))))))
+        if: (inputs.force-stage == 'true' || (inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' ||startsWith(github.ref, 'refs/heads/release/') ||startsWith(github.ref, 'refs/heads/versioning/') ||(contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/'))) ||(github.event_name == 'pull_request' &&(contains(github.event.pull_request.labels.*.name, 'stage') || startsWith(github.head_ref, 'versioning/')))))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-stage-task))
         uses: docker/login-action@v4.5.2
         with:
           registry: ${{ inputs.docker-stage-repository }}
@@ -234,17 +234,17 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-stage-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-stage-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-stage-task)) }}
 
       - name: Execute Mise Check Task
         if: (contains(inputs.on-tag, inputs.mise-check-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-check-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-check-task)) }}
 
       - name: Docker Registry Login To Promote
-        if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) ))
+        if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) )) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-promote-task))
         uses: docker/login-action@v4.5.2
         with:
           registry: ${{ inputs.docker-promote-repository }}
@@ -256,7 +256,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-promote-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-promote-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-promote-task)) }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''

--- a/.github/workflows/mise-kotlin-npm-workflow.yml
+++ b/.github/workflows/mise-kotlin-npm-workflow.yml
@@ -118,27 +118,27 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-lint-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-lint-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-lint-task)) }}
 
       - name: Execute Mise Build Task
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-build-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-build-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-build-task)) }}
 
       - name: Execute Mise Test Task
         if: (contains(inputs.on-tag, inputs.mise-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-test-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-test-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-test-task)) }}
 
       - name: Execute Mise Stage Task
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-stage-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-stage-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-stage-task)) }}
         env:
           FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -147,14 +147,14 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-check-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-check-task)) }}
 
       - name: Execute Mise Promote Task
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-promote-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-promote-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-promote-task)) }}
         env:
           FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
 

--- a/.github/workflows/mise-nodejs-workflow.yml
+++ b/.github/workflows/mise-nodejs-workflow.yml
@@ -170,7 +170,7 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-lint-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-lint-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-lint-task)) }}
 
       - if: inputs.docker-buildx-platform != ''
         name: Setup Docker Buildx for Specified Platforms
@@ -182,16 +182,16 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-build-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-build-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-build-task)) }}
 
       - name: Execute Mise Test Task
         if: (contains(inputs.on-tag, inputs.mise-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-test-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-test-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-test-task)) }}
 
-      - if: inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage')))
+      - if: inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage'))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-stage-task))
         name: Docker Registry Login to Stage
         uses: docker/login-action@v4.5.2
         with:
@@ -204,9 +204,9 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-stage-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-stage-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-stage-task)) }}
 
-      - if: inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')))
+      - if: inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-promote-task))
         name: Docker Registry Login To Promote
         uses: docker/login-action@v4.5.2
         with:
@@ -216,7 +216,7 @@ jobs:
 
       - name: Setup Npm with NpmJs Repository
         id: setup_npm_npmjs_pkg
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-promote-task))
         uses: komune-io/fixers-gradle/.github/actions/setup-npm-github-pkg@main
         with:
           npm-auth-token: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
@@ -227,14 +227,14 @@ jobs:
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-check-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-check-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-check-task)) }}
 
       - name: Execute Mise Promote Task
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))
         uses: komune-io/fixers-gradle/.github/actions/mise-step-prepost@main
         with:
           mise-task: ${{ inputs.mise-promote-task }}
-          skip: ${{ contains(inputs.skip-tasks, inputs.mise-promote-task) }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-promote-task)) }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''


### PR DESCRIPTION
## Summary
Follow-up to #192, addressing two CodeRabbit findings that were still valid against merged `main`:

1. **Substring-match bug.** `contains(inputs.skip-tasks, inputs.make-*-task)` did substring containment, not exact-token matching. Under default task names (`lint`/`build`/`test`/`stage`/`check`/`promote`) this never misfired, but a caller with a renamed task (e.g. `mise-build-task: 'build-native'`) setting `skip-tasks: 'check,build-docs'` would accidentally also skip the real `build` task, since `"build"` is a substring of `"build-docs"`. Fixed by wrapping both operands with comma delimiters (`format(',{0},', ...)`) before the substring check, so only exact tokens match.
2. **Unnecessary login/setup work when a task is skipped.** The Docker registry login steps (stage/promote) and the npm/npmjs registry setup step in `mise-nodejs-workflow.yml` ran even when their corresponding task was listed in `skip-tasks` — wasted login for a task that wouldn't execute. Gated those steps' `if:` on the same skip decision.

Note: the first round of CodeRabbit review comments on #192 (about `secrets.X != ''` used directly in `if:` conditions) is already resolved — that approach was reverted before merge in favor of the caller-driven `skip-tasks` mechanism.

## Changes
- `make-jvm-workflow.yml`, `mise-jvm-workflow.yml`, `mise-nodejs-workflow.yml`, `mise-kotlin-npm-workflow.yml`: exact-token `skip-tasks` matching on all task steps.
- `make-jvm-workflow.yml`, `mise-jvm-workflow.yml`: gate Docker Registry Login to Stage/Promote on the stage/promote skip decision.
- `mise-nodejs-workflow.yml`: gate Docker Registry Login to Stage/Promote and Setup Npm with NpmJs Repository on the corresponding skip decision.

## Test plan
- [ ] YAML validated (`ruby -ryaml`) on all four changed files.
- [ ] Confirm `skip-tasks: 'check'` still skips only `check`, not any task whose name happens to contain "check" as a substring or vice versa.
- [ ] Confirm normal (non-skip) runs still log in to Docker/npmjs registries as before.