### PR TITLE
fix: skip sonarcloud-analysis on Dependabot PRs in this repo's own CI

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -39,6 +39,8 @@ jobs:
     permissions:
       contents: write  # Required for gradle dependency-submission
       pull-requests: read  # Required for sonarcloud PR analysis
+    with:
+      with-sonarcloud: ${{ github.actor != 'dependabot[bot]' }}
     secrets:
       FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
 


### PR DESCRIPTION
## Summary
This repo's own `dev.yml` calls `./.github/workflows/sec-workflow.yml` locally (self-hosting). Its `sec / sonarcloud-analysis` job was failing on Dependabot PRs (e.g. #190) for the same reason fixed in #192 for downstream consumers: `FIXERS_SONAR_TOKEN` is unavailable on Dependabot-triggered `pull_request` runs, so the Sonar scan/quality-gate steps fail auth.

`sec-workflow.yml` already exposes a `with-sonarcloud` input for exactly this case (added prior to this session). This repo just wasn't using it on itself.

Note: `sec / gradle-dependency-analysis` on #190 already passes — confirms the actor-gated dependency-submission fix from #192/#193 works correctly in production.

## Changes
- `dev.yml`: pass `with-sonarcloud: ${{ github.actor != 'dependabot[bot]' }}` to the `sec` job.

## Test plan
- [ ] Confirm #190 (or any Dependabot PR) goes green on `sec / sonarcloud-analysis` after this merges and #190 gets a fresh run reflecting it (rebase or new push — local `uses: ./...` workflow refs resolve from the PR's own merge commit, so #190 needs a fresh event to pick this up).
- [ ] Confirm a normal (non-Dependabot) PR still runs the Sonar scan as before.