### PR TITLE
fix: use full-history checkout in mise-jvm-workflow for Sonar blame

### DIFF
--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -174,6 +174,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
+        with:
+          # Full history so the Sonar Gradle scanner can blame files and detect
+          # new code against the target branch during pull request analysis.
+          fetch-depth: 0
 
       - name: Install Mise
         uses: jdx/mise-action@v4


### PR DESCRIPTION
## Summary
`make-jvm-workflow.yml` deliberately checks out with `fetch-depth: 0` (with a comment explaining Sonar blame needs full history). Its mise counterpart checked out at the default depth 1, so Sonar analysis run via `mise-jvm-workflow.yml` had no blame data and no new-code detection on PRs. Fork drift between the two parallel workflow families.

## Changes
- `.github/workflows/mise-jvm-workflow.yml`: add `with: fetch-depth: 0` (plus the same explanatory comment) to the `Checkout Repository` step of `run-dev-tasks`, matching `make-jvm-workflow.yml`.

Root cause (workflow duplication between the make/mise families) is tracked separately.

## Verification
- `actionlint` is not installed in this environment; YAML parsed and the resulting step asserted structurally with `ruby -ryaml`:
  `["run-dev-tasks", {"name"=>"Checkout Repository", "uses"=>"actions/checkout@v7", "with"=>{"fetch-depth"=>0}}]`
- Confirmed `mise-jvm-workflow.yml` has exactly one checkout step, as does `make-jvm-workflow.yml`, so the two are now identical on this point.

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to fetch complete repository history, improving the reliability of code quality analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->