### PR TITLE
fix: add concurrency group to dev.yml to cancel superseded PR runs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,6 +11,12 @@ on:
       - main
       - 'release/*'
 
+# Only cancel superseded pull request runs. Pushes to main, release branches and
+# scheduled runs queue instead, so a publish is never interrupted mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dev:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false


### PR DESCRIPTION
## Summary
No workflow in the repo declared a `concurrency:` group. `dev.yml` triggers on push, pull_request and a nightly schedule, so every push to a PR stacked a new full run (build + test + sonar) on top of the still-running previous one.

## Changes
- `.github/workflows/dev.yml`: add a top-level
  ```yaml
  concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
  ```

`cancel-in-progress` is deliberately gated on `pull_request` so pushes to `main` / `release/*` and the nightly schedule queue rather than being cancelled mid-publish.

## Why only `dev.yml`
`dev.yml` is this repo's only entry-point workflow. The other nine files are `workflow_call`-only reusable workflows — a called workflow runs inside the caller's run and is already covered by the caller's concurrency group. Adding a group inside them would also be actively risky for downstream consumers, since `github.workflow` inside a reusable workflow resolves to the *caller's* workflow name, so the group would collide with the caller's own group.

## Verification
- `actionlint` is not installed in this environment; YAML parsed and asserted with `ruby -ryaml`:
  - `concurrency` -> `{"group"=>"${{ github.workflow }}-${{ github.ref }}", "cancel-in-progress"=>"${{ github.event_name == 'pull_request' }}"}`
  - triggers and `jobs` (`dev`, `sec`) unchanged.
- Behaviour is observable on this PR itself: a second push should cancel the first run.

Closes #199