### PR TITLE
fix: sync build-composite sources instead of copying them

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,10 @@ fixers {
 }
 
 
-tasks.register<Copy>("copyConfigSources") {
+// Sync, not Copy: the destination must mirror the source exactly, otherwise a file
+// deleted or renamed in build-composite leaves a stale copy behind that still
+// compiles and ships in the published jar.
+tasks.register<Sync>("copyConfigSources") {
 	group = "fixers"
 	description = "Copy configuration sources to the config module"
 	logger.lifecycle("Copying configuration sources")
@@ -47,7 +50,7 @@ tasks.register<Delete>("cleanConfigSources") {
 	delete("config/src/main/kotlin/io/komune/fixers/gradle/config")
 }
 
-tasks.register<Copy>("copyPluginSources") {
+tasks.register<Sync>("copyPluginSources") {
 	group = "fixers"
 	description = "Copy plugin sources to the plugin module"
 	logger.lifecycle("Copying plugin sources")


### PR DESCRIPTION
## Summary
`copyConfigSources` and `copyPluginSources` mirror `build-composite/src/main/kotlin/...` into `config`/`plugin`, but used `Copy`, which only ever adds files. When a file was deleted or renamed in `build-composite`, the stale `.kt` copy stayed at the destination, still compiled, and shipped in the published jars until someone ran a manual `clean`.

## Changes
- `build.gradle.kts`: `tasks.register<Copy>` -> `tasks.register<Sync>` for both `copyConfigSources` and `copyPluginSources`, with a short comment explaining why.

## What I did *not* change
Kept `cleanConfigSources` / `cleanPluginSources` and their wiring into `:config:clean` / `:plugin:clean`. Sync fixes staleness *during* a build, but it does not remove the generated sources from the working tree on `clean` — that is what those `Delete` tasks are for, so they aren't redundant.

Also confirmed the destinations are exclusively generated (both paths are gitignored, and `config`'s `generateToolVersions` writes to `build/generated/fixers/kotlin`, not into the synced tree), so `Sync` cannot delete anything hand-written.

## Verification
- `./gradlew :config:build :plugin:build -x test` -> BUILD SUCCESSFUL (detekt included).
- Manual Sync-semantics check:
  1. Added `build-composite/src/main/kotlin/io/komune/fixers/gradle/config/SyncProbe.kt`, ran `:copyConfigSources` -> `config/src/main/kotlin/io/komune/fixers/gradle/config/SyncProbe.kt` present.
  2. Deleted the source file, re-ran `:copyConfigSources` -> the destination copy was removed (`No such file or directory`). Under the old `Copy` it would have survived.
  3. Working tree left clean apart from `build.gradle.kts`.

Closes #198