### PR TITLE
chore: SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -32,7 +32,7 @@ runs:
         path: ${{ inputs.storybook-dir }}${{ inputs.storybook-static-dir-separator }}${{ inputs.storybook-static-dir }}
     - name: Publish to Chromatic
       id: chromatic
-      uses: chromaui/action@v16
+      uses: chromaui/action@1bbb5819252d9782cb7d77122d9becae467def18 # v16.10.1
       with:
         projectToken: ${{ inputs.project-token }}
         workingDir: ${{ inputs.storybook-dir }}

--- a/.github/actions/jvm/action.yml
+++ b/.github/actions/jvm/action.yml
@@ -38,7 +38,7 @@ runs:
         java-version: ${{ inputs.java-version }}
     - if: inputs.with-gradle == 'true'
       name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
         build-scan-publish: ${{ inputs.with-gradle-build-scan-publish }}
         build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"

--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - if: steps.detect-package-manager.outputs.package-manager == 'pnpm'
       name: Install pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
         version: latest
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" only covers .github/workflows; the composite actions under
+    # .github/actions/*/action.yml need to be listed explicitly so their
+    # SHA-pinned `uses:` are kept up to date too.
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"

--- a/.github/workflows/make-jvm-workflow.yml
+++ b/.github/workflows/make-jvm-workflow.yml
@@ -181,7 +181,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add Firefox to Run Kotlin test
-        uses: browser-actions/setup-firefox@v1
+        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
 
       - name: Initialize Java and Gradle Environment
         uses: komune-io/fixers-gradle/.github/actions/jvm@main
@@ -202,7 +202,7 @@ jobs:
 
       - name: Setup Docker Buildx for Specified Platforms
         if: inputs.docker-buildx-platform != ''
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           platforms: ${{ inputs.docker-buildx-platform }}
 
@@ -228,7 +228,7 @@ jobs:
 
       - name: Docker Registry Login to Stage
         if: (inputs.force-stage == 'true' || (inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' ||startsWith(github.ref, 'refs/heads/release/') ||startsWith(github.ref, 'refs/heads/versioning/') ||(contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/'))) ||(github.event_name == 'pull_request' &&(contains(github.event.pull_request.labels.*.name, 'stage') || startsWith(github.head_ref, 'versioning/')))))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-stage-task))
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.docker-stage-repository }}
           username: ${{ secrets.DOCKER_STAGE_USERNAME }}
@@ -251,7 +251,7 @@ jobs:
 
       - name: Docker Registry Login To Promote
         if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) )) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-promote-task))
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.docker-promote-repository }}
           username: ${{ secrets.DOCKER_PROMOTE_USERNAME }}

--- a/.github/workflows/make-kotlin-npm-workflow.yml
+++ b/.github/workflows/make-kotlin-npm-workflow.yml
@@ -135,7 +135,7 @@ jobs:
 
       - if: inputs.docker-buildx-platform != ''
         name: Setup Docker Buildx for Specified Platforms
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           platforms: ${{ inputs.docker-buildx-platform }}
 

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -171,7 +171,7 @@ jobs:
 
       - if: inputs.docker-buildx-platform != ''
         name: Setup Docker Buildx for Specified Platforms
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           platforms: ${{ inputs.docker-buildx-platform }}
 
@@ -190,7 +190,7 @@ jobs:
 
       - if: inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage')))
         name: Docker Registry Login to Stage
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.docker-stage-repository }}
           username: ${{ secrets.DOCKER_STAGE_USERNAME }}
@@ -205,7 +205,7 @@ jobs:
 
       - if: inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')))
         name: Docker Registry Login To Promote
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.docker-promote-repository }}
           username: ${{ secrets.DOCKER_PROMOTE_USERNAME }}

--- a/.github/workflows/mise-jvm-workflow.yml
+++ b/.github/workflows/mise-jvm-workflow.yml
@@ -176,10 +176,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
 
       - name: Add Firefox to Run Kotlin test
-        uses: browser-actions/setup-firefox@v1
+        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
 
       - name: Initialize Java and Gradle Environment
         uses: komune-io/fixers-gradle/.github/actions/jvm@main
@@ -199,7 +199,7 @@ jobs:
 
       - name: Setup Docker Buildx for Specified Platforms
         if: inputs.docker-buildx-platform != ''
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           platforms: ${{ inputs.docker-buildx-platform }}
 
@@ -223,7 +223,7 @@ jobs:
 
       - name: Docker Registry Login to Stage
         if: (inputs.force-stage == 'true' || (inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' ||startsWith(github.ref, 'refs/heads/release/') ||startsWith(github.ref, 'refs/heads/versioning/') ||(contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/'))) ||(github.event_name == 'pull_request' &&(contains(github.event.pull_request.labels.*.name, 'stage') || startsWith(github.head_ref, 'versioning/')))))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-stage-task))
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.docker-stage-repository }}
           username: ${{ secrets.DOCKER_STAGE_USERNAME || github.actor }}
@@ -245,7 +245,7 @@ jobs:
 
       - name: Docker Registry Login To Promote
         if: (inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')) )) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-promote-task))
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.docker-promote-repository }}
           username: ${{ secrets.DOCKER_PROMOTE_USERNAME }}

--- a/.github/workflows/mise-kotlin-npm-workflow.yml
+++ b/.github/workflows/mise-kotlin-npm-workflow.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
 
       - name: Initialize Java and Gradle Environment
         uses: komune-io/fixers-gradle/.github/actions/jvm@main

--- a/.github/workflows/mise-nodejs-workflow.yml
+++ b/.github/workflows/mise-nodejs-workflow.yml
@@ -142,7 +142,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
 
       - name: Initialize Node.js Environment
         uses: komune-io/fixers-gradle/.github/actions/nodejs@main
@@ -174,7 +174,7 @@ jobs:
 
       - if: inputs.docker-buildx-platform != ''
         name: Setup Docker Buildx for Specified Platforms
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           platforms: ${{ inputs.docker-buildx-platform }}
 
@@ -193,7 +193,7 @@ jobs:
 
       - if: inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage'))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-stage-task))
         name: Docker Registry Login to Stage
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.docker-stage-repository }}
           username: ${{ secrets.DOCKER_STAGE_USERNAME }}
@@ -208,7 +208,7 @@ jobs:
 
       - if: inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.mise-promote-task))
         name: Docker Registry Login To Promote
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.docker-promote-repository }}
           username: ${{ secrets.DOCKER_PROMOTE_USERNAME }}

--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -57,10 +57,10 @@ jobs:
           java-distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
       - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v6
+        uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
       - name: Submit Dependency Graph
         if: github.actor != 'dependabot[bot]'
-        uses: gradle/actions/dependency-submission@v6
+        uses: gradle/actions/dependency-submission@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           additional-arguments: -I ${{ steps.jvm.outputs.setup_gradle_github_pkg }} --no-configuration-cache
           build-scan-publish: true
@@ -103,11 +103,11 @@ jobs:
             cat sonar-project.properties
           fi
       - name: Run SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v8
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
       - name: Check SonarQube Quality Gate
-        uses: SonarSource/sonarqube-quality-gate-action@v1.2.1
+        uses: SonarSource/sonarqube-quality-gate-action@7a5fffe8e523c40e0c740b6bc2712ab503e52efa # v1.2.1
         timeout-minutes: 5
         env:
           SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}


### PR DESCRIPTION
Closes #203

## What changed

Every **third-party** action reference is now pinned to a full commit SHA with a trailing `# vX.Y.Z` comment, which is the form Dependabot understands and keeps bumping.

| action | old ref | pinned SHA | sites |
| --- | --- | --- | --- |
| `SonarSource/sonarqube-scan-action` | `v8` | `22918119…` `# v8.2.1` | 1 |
| `SonarSource/sonarqube-quality-gate-action` | `v1.2.1` | `7a5fffe8…` `# v1.2.1` | 1 |
| `docker/login-action` | `v4.6.0` | `dbcb8138…` `# v4.6.0` | 8 |
| `docker/setup-buildx-action` | `v4` | `bb05f3f5…` `# v4.2.0` | 5 |
| `chromaui/action` | `v16` | `1bbb5819…` `# v16.10.1` | 1 |
| `jdx/mise-action` | `v4` | `7e36c90d…` `# v4.2.4` | 3 |
| `browser-actions/setup-firefox` | `v1` | `0bc507dd…` `# v1.7.2` | 2 |
| `pnpm/action-setup` | `v5` | `fc06bc12…` `# v5.0.0` | 1 |
| `gradle/actions/setup-gradle` | `v5` | `07231958…` `# v5.0.2` | 1 |
| `gradle/actions/wrapper-validation` | `v6` | `9c971963…` `# v6.3.0` | 1 |
| `gradle/actions/dependency-submission` | `v6` | `9c971963…` `# v6.3.0` | 1 |

Every SHA was resolved from the tag that was previously in use (`gh api repos/<owner>/<repo>/commits/<tag>`), so **no version changes** — behaviour is identical, only the reference is immutable now. The comment records the precise release tag that SHA carries (e.g. `v8` resolved to `v8.2.1`), so the floating majors on `jdx/mise-action`, `docker/setup-buildx-action`, `chromaui/action` and the two `gradle/actions` entries are now explicit as well.

Also: `.github/dependabot.yml` now lists `/.github/actions/*` in addition to `/` for the `github-actions` ecosystem. The `/` directory only covers `.github/workflows`, so the SHAs inside the composite actions (`chromatic`, `jvm`, `nodejs`) would have silently gone stale otherwise — that would have turned the pinning into a liability rather than a fix.

## Decisions beyond the issue text

- **First-party `actions/*` are deliberately left on tags** (`checkout@v7`, `setup-java@v5`, `setup-node@v6`, `upload-artifact@v7`, `download-artifact@v8`, `cache@v5`, `deploy-pages@v5`, `upload-pages-artifact@v4`). They are published by GitHub itself from the same trust domain as the runner; pinning them buys little and costs a lot of Dependabot churn.
- **Scope was widened slightly past the four actions named in the issue.** `docker/setup-buildx-action`, `browser-actions/setup-firefox`, `pnpm/action-setup` and `gradle/actions/*` are also third-party and run inside the same jobs that hold the registry credentials and the Sonar token; leaving them floating on a major would have left the hole the issue is about half-open. It is the same one-line mechanical change per site.
- **Internal `komune-io/fixers-gradle/.github/actions/…@main` references are untouched** — that is #207's subject.

## Verification

- `actionlint` (1.7.12) over the whole repo: clean, exit 0.
- YAML parse of all 23 files under `.github/` (workflows, composite actions, dependabot.yml): all parse.
- Assertion script: every `uses:` not in `actions/*`, `komune-io/*` or `./…` matches `@[0-9a-f]{40}$`.

## Merge order

Touches workflow YAML, as do #202 and #207. This PR only rewrites `uses:` lines, so it should not textually collide with either — #202 adds inputs/`if:` guards and #207 edits `permissions:`/chromatic inputs. If a conflict does appear, it will be a one-line `uses:` hunk; take this branch's version (the SHA).