### PR TITLE
fix: close skip-tasks gaps in the make-* reusable workflows

### DIFF
--- a/.github/workflows/make-kotlin-npm-workflow.yml
+++ b/.github/workflows/make-kotlin-npm-workflow.yml
@@ -57,6 +57,12 @@ on:
         type: "string"
         default: "promote"
 
+      skip-tasks:
+        description: "Comma-separated list of task names (matching the values of the make-*-task inputs, e.g. 'check' or 'check,promote') to skip entirely for this run — e.g. when a caller knows a task's secret dependency is unavailable."
+        required: false
+        type: "string"
+        default: ""
+
       docker-buildx-platform:
         description: "Specify the target platforms for Docker buildx, such as 'linux/amd64,linux/arm64'. Leave empty to use the default platform."
         required: false
@@ -132,6 +138,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-lint-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-lint-task)) }}
 
       - if: inputs.docker-buildx-platform != ''
         name: Setup Docker Buildx for Specified Platforms
@@ -144,6 +151,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-build-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-build-task)) }}
 
       - name: Execute Make Test Task
         if: (contains(inputs.on-tag, inputs.make-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
@@ -151,6 +159,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-test-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-test-task)) }}
 
       - name: Execute Make Stage Task
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage'))
@@ -158,6 +167,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-stage-task)) }}
         env:
           FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -167,6 +177,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-check-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-check-task)) }}
 
       - name: Execute Make Promote Task
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))
@@ -174,6 +185,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-promote-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-promote-task)) }}
         env:
           FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
 

--- a/.github/workflows/make-nodejs-workflow.yml
+++ b/.github/workflows/make-nodejs-workflow.yml
@@ -85,6 +85,12 @@ on:
         type: "string"
         default: "promote"
 
+      skip-tasks:
+        description: "Comma-separated list of task names (matching the values of the make-*-task inputs, e.g. 'check' or 'check,promote') to skip entirely for this run — e.g. when a caller knows a task's secret dependency is unavailable."
+        required: false
+        type: "string"
+        default: ""
+
       docker-stage-repository:
         description: "The Docker registry to which images should be staged. Defaults to GitHub Container Registry (ghcr.io)."
         required: false
@@ -168,6 +174,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-lint-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-lint-task)) }}
 
       - if: inputs.docker-buildx-platform != ''
         name: Setup Docker Buildx for Specified Platforms
@@ -180,6 +187,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-build-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-build-task)) }}
 
       - name: Execute Make Test Task
         if: (contains(inputs.on-tag, inputs.make-test-task) && startsWith(github.ref, 'refs/tags/')) || (!startsWith(github.ref, 'refs/tags/'))
@@ -187,8 +195,9 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-test-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-test-task)) }}
 
-      - if: inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage')))
+      - if: inputs.with-stage-docker-registry-login == 'true' && ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'stage') && startsWith(github.ref, 'refs/tags/')) ) || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stage'))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-stage-task))
         name: Docker Registry Login to Stage
         uses: docker/login-action@v4.6.0
         with:
@@ -202,8 +211,9 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-stage-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-stage-task)) }}
 
-      - if: inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/')))
+      - if: inputs.with-promote-docker-registry-login == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-promote-task))
         name: Docker Registry Login To Promote
         uses: docker/login-action@v4.6.0
         with:
@@ -213,7 +223,7 @@ jobs:
 
       - name: Setup Npm with NpmJs Repository
         id: setup_npm_npmjs_pkg
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))) && !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-promote-task))
         uses: komune-io/fixers-gradle/.github/actions/setup-npm-github-pkg@main
         with:
           npm-auth-token: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
@@ -225,6 +235,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-check-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-check-task)) }}
 
       - name: Execute Make Promote Task
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') ||  (contains(inputs.on-tag, 'promote') && startsWith(github.ref, 'refs/tags/'))
@@ -232,6 +243,7 @@ jobs:
         with:
           make-file: ${{ inputs.make-file }}
           make-step: ${{ inputs.make-promote-task }}
+          skip: ${{ contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-promote-task)) }}
 
       - name: Upload Artifact if Specified
         if: inputs.artifact-name != '' && inputs.artifact-path != ''

--- a/.github/workflows/publish-storybook-workflow.yml
+++ b/.github/workflows/publish-storybook-workflow.yml
@@ -68,6 +68,12 @@ on:
         type: "string"
         default: "make_docs.mk"
 
+      skip-tasks:
+        description: "Comma-separated list of task names (matching the values of the make-*-task inputs of make-nodejs-workflow, e.g. 'check' or 'check,promote') to skip entirely for this run — e.g. when a caller knows a task's secret dependency is unavailable."
+        required: false
+        type: "string"
+        default: ""
+
     secrets:
       FIXERS_CHROMATIC_PROJECT_TOKEN:
         required: false
@@ -92,6 +98,7 @@ jobs:
       docker-stage-repository: ${{ inputs.docker-stage-repository }}
       docker-promote-repository: ${{ inputs.docker-promote-repository }}
       on-tag: ${{ inputs.on-tag }}
+      skip-tasks: ${{ inputs.skip-tasks }}
     secrets:
       DOCKER_STAGE_USERNAME: ${{ secrets.DOCKER_STAGE_USERNAME }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.DOCKER_STAGE_PASSWORD }}


### PR DESCRIPTION
Closes #202

## What changed

`skip-tasks` was implemented in `make-jvm-workflow.yml` and the three `mise-*` workflows but missing from the two `make-*` ones, so a caller could not skip stages consistently.

**`make-nodejs-workflow.yml`**
- new `skip-tasks` input (same description/type/default as the existing four)
- `skip:` wired on all six `make-step-prepost` steps (lint, build, test, stage, check, promote)
- the two `docker/login-action` steps (:191, :206) now carry `&& !contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-stage-task))` / `…make-promote-task))`, exactly as `mise-nodejs-workflow.yml:194,209` already does — a skipped stage no longer authenticates against a registry it will never push to
- **also** gated *Setup Npm with NpmJs Repository* on the promote skip. It was the one remaining unguarded credential step in that file and the mise variant already guards it (`mise-nodejs-workflow.yml:219`); leaving it out would have meant `skip-tasks: promote` still handed the npmjs token to the runner. Its `if:` needed parenthesising around the existing `||` chain to bind the new `&&` correctly.

**`make-kotlin-npm-workflow.yml`**
- new `skip-tasks` input, `skip:` wired on all six `make-step-prepost` steps. No docker-login steps in this file, so nothing to gate.

**`publish-storybook-workflow.yml`**
- new `skip-tasks` input, passed through to the `package-storybook` job that calls `make-nodejs-workflow.yml` (:94).

The matching idiom is the existing exact-token one, verbatim — `contains(format(',{0},', inputs.skip-tasks), format(',{0},', inputs.make-X-task))`. No new scheme.

## Not done: sec-workflow.yml

The issue lists `sec-workflow.yml` as a fourth gap. I left it alone deliberately: it has no `make-*-task` / `mise-*-task` inputs, so there is nothing for a `skip-tasks` token to match against — the input would have to grow a bespoke vocabulary of job names, which is precisely the "new matching scheme" worth avoiding. The coarse `with-sonarcloud` boolean already covers the only skippable job. Adding it there is not clean, so it is out.

## Verification

- `actionlint` 1.7.12 over the repo: clean, exit 0 (it type-checks `inputs.skip-tasks` references against the `workflow_call` input declarations, so a missing declaration or a typo'd input name would have failed here).
- Structural assertion over every workflow: every step whose `uses:` matches `*-step-prepost` has a `with.skip` referencing `skip-tasks` — 36/36 across all six workflows.
- Asserted the three new input declarations parse and that `package-storybook.with.skip-tasks == "${{ inputs.skip-tasks }}"`.
- Both `docker-registry-login` `if:` expressions in make-nodejs confirmed to reference `skip-tasks`.
- Not runtime-tested: none of these reusable workflows are exercised by this repo's own `dev.yml` (which only calls `make-jvm` and `sec`).

## Merge order / conflicts

Touches workflow YAML, as do #203 (PR #213) and #207.

- vs **#213** (SHA-pinning): #213 rewrites only `uses:` lines; this PR touches `inputs:`, `if:` and `with:` lines. The one adjacency is `docker/login-action` — #213 edits its `uses:`, this PR edits the `- if:` line two lines above. Git should merge both hunks; if it does not, keep #213's SHA on the `uses:` line and this branch's `if:` line.
- vs **#207**: no overlap expected (release-workflow.yml + chromatic action).

Merge order is not otherwise significant. One note: `publish-storybook-workflow.yml` calls `make-nodejs-workflow.yml@main`, so the new `skip-tasks:` passthrough only becomes valid once this lands on `main` — both sides land in the same commit, so there is no window where it is broken, but it does mean the passthrough cannot be exercised from a PR branch. That is the `@main` self-reference problem tracked in #207.