### PR TITLE
fix: least-privilege release token and correct chromatic artifact wiring

### DIFF
--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -22,13 +22,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
+    # The caller is expected to have checked out the repository with
+    # fetch-depth: 0 already — Chromatic needs the full history to diff builds.
     - name: Download artifacts
       uses: actions/download-artifact@v8
       with:
-        name: storybook-static
+        name: ${{ inputs.storybook-static-dir }}
         path: ${{ inputs.storybook-dir }}${{ inputs.storybook-static-dir-separator }}${{ inputs.storybook-static-dir }}
     - name: Publish to Chromatic
       id: chromatic

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   create-release-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push the release branch and the release tag
+      pull-requests: write   # gh pr create
     env:
       RELEASE_BRANCH: versioning/${{ inputs.version }}
       RELEASE_TAG: refs/tags/${{ inputs.version }}


### PR DESCRIPTION
Closes #207

Three of the four items in the issue are fixed here. The fourth (`@main` self-references) has no clean fix — analysis posted as a comment on the issue, summarised below.

## 1. `permissions:` on release-workflow.yml

The job pushes the release branch (`:61`, `:84`), pushes the tag (`:69`) and runs `gh pr create` (`:93`), all on the default token permissions. Scoped to exactly what those need:

```yaml
permissions:
  contents: write        # push the release branch and the release tag
  pull-requests: write   # gh pr create
```

Job-level rather than workflow-level, matching the idiom already used in `sec-workflow.yml:41,73` and `publish-storybook-workflow.yml:128`. Note this only constrains the fallback `github.token` path — when a caller supplies `FIXERS_PUBLISH_GITHUB_TOKEN`, that PAT carries its own scopes and is unaffected. It is still correct to add, since the fallback is the default.

## 2. Chromatic action honours `storybook-static-dir`

`actions/download-artifact` had `name: storybook-static` hardcoded, while the artifact is uploaded under `artifact-name: ${{ inputs.storybook-static-dir }}` (`publish-storybook-workflow.yml:89`). The two only agreed because `storybook-static-dir` defaults to `storybook-static`; **any caller overriding it got a "an artifact with this name was not found" failure.** Now `name: ${{ inputs.storybook-static-dir }}`, which the caller already threads through at `:119`.

## 3. Redundant nested checkout removed

`actions/checkout@v6` inside the composite action re-cloned the repository that the calling job had already checked out with `fetch-depth: 0` (`publish-storybook-workflow.yml:107-109`) — and did so pinned at v6 while every other checkout in the repo is v7. Removed, with a comment recording the contract (the caller must check out with full history; Chromatic needs it to diff builds). Verified the only in-repo caller satisfies this.

## 4. `@main` self-references — investigated, not fixed

**There is no clean fix, so per the issue I have commented the analysis rather than forced a change.** Short version:

- Changing `komune-io/fixers-gradle/.github/actions/jvm@main` to `./.github/actions/jvm` **breaks every downstream consumer**. These are reusable workflows whose whole purpose is to be called from other komune repos; a `./` path resolves against the *caller's* checked-out workspace, where `.github/actions/jvm` does not exist. It would fix PR-testing here at the cost of breaking the primary use case.
- The obvious parameterisation, `uses: …@${{ inputs.actions-ref }}`, is impossible: GitHub does not evaluate expression syntax in a step's `uses:` field. Same blocker for `@${{ github.sha }}`.
- The same constraint applies to composite-action → composite-action references (`make-step-prepost` → `make-step-optional@main`), so it cannot be fixed one layer down either.

The realistic mitigation is additive rather than a rewrite: give this repo's own `dev.yml` a smoke job that exercises the composite actions through `./.github/actions/…` directly. Local `./` references *do* work for a workflow that lives in and is called from this repo, so an action-modifying PR would then test its own code, while consumers keep the `@main` entry points unchanged. That is new CI surface rather than a fix to existing lines, so it belongs in its own change — detailed in the issue comment.

## Verification

- `actionlint` 1.7.12 over the repo: clean, exit 0.
- YAML parse of all files under `.github/`: all parse.
- Asserted structurally that `create-release-branch.permissions == {contents: write, pull-requests: write}`.
- Asserted the chromatic action's three remaining steps, and that its `download-artifact.name` now equals the `artifact-name` the uploader uses — both are `${{ inputs.storybook-static-dir }}`, so they cannot drift again.
- Asserted the calling `publish-chromatic` job still checks out with `fetch-depth: 0` before invoking the action, which is what makes the nested checkout safe to drop.
- Not runtime-tested: `publish-storybook-workflow.yml` and `release-workflow.yml` are not exercised by this repo's own `dev.yml`.

## Merge order / conflicts

Touches workflow YAML, as do #203 (PR #213) and #202 (PR #214).

- vs **#213**: #213 SHA-pins `chromaui/action` and `actions/*`. It leaves `actions/checkout@v6` on the line this PR deletes (it does not pin first-party `actions/*`), so there should be no textual conflict. If one appears, this PR's deletion wins.
- vs **#214**: no overlap — #214 does not touch `release-workflow.yml` or the chromatic action, and its `publish-storybook-workflow.yml` edits are in the inputs block and the `package-storybook` job, not the `publish-chromatic` job.

## Noted, not fixed

The `make-*` / `mise-*` reusable workflows also declare no `permissions:` block. I deliberately left them: they push to GHCR and npm on behalf of consumer repos, so guessing at a least-privilege set risks breaking downstream publishes, and it needs a survey of what consumers actually rely on. Worth its own issue.