### PR TITLE
Import detekt reports in every sonar module

### DIFF
--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/Sonar.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/Sonar.kt
@@ -41,7 +41,11 @@ class Sonar(
 
     /**
      * The path to the JaCoCo XML report.
-     * Includes paths for both standard JVM projects (test/) and Kotlin Multiplatform projects (jvmTest/).
+     *
+     * Sonar resolves this Ant-style pattern against the base directory of each analysed module,
+     * where `**` also matches zero directories: it therefore covers both standard JVM projects
+     * (`build/reports/jacoco/test/`) and Kotlin Multiplatform projects
+     * (`build/reports/jacoco/jvmTest/`, written by the `jacocoJvmTestReport` task).
      */
     val jacoco: Property<String> = project.property(
         envKey = "FIXERS_SONAR_JACOCO",
@@ -60,7 +64,12 @@ class Sonar(
 
     /**
      * The path to the Detekt XML report.
-     * Uses the merged report from the root project.
+     *
+     * Uses the merged report produced by the `detektReportMergeXml` task of the root project.
+     * A relative path is resolved against the root project directory before being handed to the
+     * Gradle scanner, so that every analysed module points at that single merged report instead of
+     * looking for a non-existing `<module>/build/reports/detekt/merge.xml`
+     * (see `SonarQubeConfigurator.resolveDetektReportPaths`). Absolute paths are used as-is.
      */
     val detekt: Property<String> = project.property(
         envKey = "FIXERS_SONAR_DETEKT_REPORT_PATHS",

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/DetektConfiguration.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/DetektConfiguration.kt
@@ -5,6 +5,7 @@ import dev.detekt.gradle.extensions.DetektExtension
 import dev.detekt.gradle.report.ReportMergeTask
 import io.komune.fixers.gradle.config.fixers
 import org.gradle.api.Project
+import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.register
@@ -12,6 +13,23 @@ import org.gradle.kotlin.dsl.withType
 
 fun Project.getDetektReportMergeXmlFile(): Provider<RegularFile> {
     return rootProject.layout.buildDirectory.file("reports/detekt/merge.xml")
+}
+
+/**
+ * All Detekt reports of this project with the given extension, excluding the merged report itself
+ * (the root project writes `merge.xml`/`merge.sarif` in the very same directory).
+ *
+ * A project can hold several Detekt tasks - Kotlin Multiplatform registers one per source set and
+ * per compilation - so the merge tasks must collect every report, not only the one produced by the
+ * default `detekt` task.
+ */
+internal fun Project.detektReportsWithExtension(extension: String): Provider<FileTree> {
+    return layout.buildDirectory.dir("reports/detekt").map { reportsDir ->
+        reportsDir.asFileTree.matching {
+            include("*.$extension")
+            exclude("merge.$extension")
+        }
+    }
 }
 
 fun Project.configureDetekt() {
@@ -29,8 +47,6 @@ fun Project.configureDetekt() {
         plugins.apply("dev.detekt")
 
         pluginManager.withPlugin("dev.detekt") {
-            val detectXmlPath = layout.buildDirectory.file("reports/detekt/detekt.xml")
-            val detectSarifPath = layout.buildDirectory.file("reports/detekt/detekt.sarif")
             extensions.configure(DetektExtension::class.java) {
                 buildUponDefaultConfig.set(fixersDetekt?.buildUponDefaultConfig?.get() ?: true)
 
@@ -51,15 +67,21 @@ fun Project.configureDetekt() {
                 val sarifEnabled = fixersDetekt?.sarifReport?.get() ?: true
                 val markdownEnabled = fixersDetekt?.markdownReport?.get() ?: true
 
+                // Reports are named after the task: a project may run several Detekt tasks
+                // (Kotlin Multiplatform registers one per source set / compilation) and a shared
+                // output location makes them overwrite each other's report.
+                val detektXmlPath = layout.buildDirectory.file("reports/detekt/$name.xml")
+                val detektSarifPath = layout.buildDirectory.file("reports/detekt/$name.sarif")
+
                 reports {
                     checkstyle.required.set(checkstyleEnabled)
                     if (checkstyleEnabled) {
-                        checkstyle.outputLocation.set(file(detectXmlPath))
+                        checkstyle.outputLocation.set(file(detektXmlPath))
                     }
                     html.required.set(htmlEnabled)
                     sarif.required.set(sarifEnabled)
                     if (sarifEnabled) {
-                        sarif.outputLocation.set(file(detectSarifPath))
+                        sarif.outputLocation.set(file(detektSarifPath))
                     }
                     markdown.required.set(markdownEnabled)
                 }
@@ -68,11 +90,11 @@ fun Project.configureDetekt() {
             }
 
             detektReportMergeSarif.configure {
-                input.from(detectSarifPath)
+                input.from(detektReportsWithExtension("sarif"))
             }
 
             detektReportMergeXml.configure {
-                input.from(detectXmlPath)
+                input.from(detektReportsWithExtension("xml"))
             }
         }
     }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/SonarQubeConfigurator.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/SonarQubeConfigurator.kt
@@ -2,6 +2,7 @@ package io.komune.fixers.gradle.plugin.check
 
 import io.komune.fixers.gradle.config.model.Bundle
 import io.komune.fixers.gradle.config.model.Sonar
+import java.io.File
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.register
 import org.sonarqube.gradle.SonarExtension
@@ -92,7 +93,7 @@ class SonarQubeConfigurator(
         properties["sonar.host.url"] = sonar.url.get()
         properties["sonar.language"] = sonar.language.get()
         properties["sonar.exclusions"] = sonar.exclusions.get()
-        properties["sonar.kotlin.detekt.reportPaths"] = sonar.detekt.get()
+        properties["sonar.kotlin.detekt.reportPaths"] = resolveDetektReportPaths(sonar.detekt.get())
         properties["sonar.pullrequest.github.summary_comment"] = sonar.githubSummaryComment.get()
         properties["sonar.coverage.jacoco.xmlReportPaths"] = sonar.jacoco.get()
         properties["detekt.sonar.kotlin.config.path"] = "${project.rootDir}/${sonar.detektConfigPath.get()}"
@@ -106,5 +107,32 @@ class SonarQubeConfigurator(
         }
 
         return properties
+    }
+
+    /**
+     * Makes the Detekt report path(s) module-independent.
+     *
+     * Detekt reports are merged into a single file living in the **root** project's build
+     * directory (see [getDetektReportMergeXmlFile]), but Sonar resolves relative report paths
+     * against the base directory of *each analysed module*. A relative path therefore makes every
+     * non-root module look for `<module>/build/reports/detekt/merge.xml`, a file that never
+     * exists, and the analysis logs `Unable to import detekt report file(s)` for each of them
+     * while no Detekt issue is ever imported.
+     *
+     * Relative paths are resolved against the root project directory; absolute paths are kept
+     * as-is so a project with a non-standard layout can still point Sonar wherever it wants
+     * (via `fixers.sonar.detekt.reportPaths` / `FIXERS_SONAR_DETEKT_REPORT_PATHS`).
+     *
+     * @param paths comma-separated report paths, as configured on the Sonar model
+     * @return the same list with every relative entry made absolute
+     */
+    internal fun resolveDetektReportPaths(paths: String): String {
+        return paths.split(",")
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .joinToString(",") { path ->
+                val file = File(path)
+                if (file.isAbsolute) file.path else File(project.rootDir, path).path
+            }
     }
 }

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/DetektConfigurationTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/DetektConfigurationTest.kt
@@ -2,6 +2,7 @@ package io.komune.fixers.gradle.check
 
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.extensions.DetektExtension
+import dev.detekt.gradle.report.ReportMergeTask
 import io.komune.fixers.gradle.config.ConfigExtension
 import io.komune.fixers.gradle.plugin.check.configureDetekt
 import io.komune.fixers.gradle.plugin.check.getDetektReportMergeXmlFile
@@ -100,6 +101,55 @@ class DetektConfigurationTest {
             assertThat(task.reports.html.required.get()).isTrue()
             assertThat(task.reports.markdown.required.get()).isTrue()
         }
+    }
+
+    @Test
+    fun `should name reports after the task so several detekt tasks do not overwrite each other`(
+        @TempDir dir: File
+    ) {
+        val (root, _) = rootWithConfig(dir)
+
+        root.configureDetekt()
+        root.tasks.register("detektJvmMain", Detekt::class.java)
+
+        val outputs = root.tasks.withType(Detekt::class.java).map { task ->
+            task.reports.checkstyle.outputLocation.get().asFile.path
+        }
+        assertThat(outputs).hasSizeGreaterThan(1)
+        assertThat(outputs.distinct()).hasSameSizeAs(outputs)
+        assertThat(outputs).anyMatch { it.endsWith("reports/detekt/detekt.xml") }
+        assertThat(outputs).anyMatch { it.endsWith("reports/detekt/detektJvmMain.xml") }
+    }
+
+    @Test
+    fun `should merge every detekt report of every project except the merged ones`(@TempDir dir: File) {
+        val (root, _) = rootWithConfig(dir)
+        val child = ProjectBuilder.builder()
+            .withParent(root)
+            .withName("child")
+            .withProjectDir(File(dir, "child").apply { mkdirs() })
+            .build()
+
+        root.configureDetekt()
+
+        val rootReport = writeReport(root, "detekt.xml")
+        val rootKmpReport = writeReport(root, "detektJvmMain.xml")
+        val childReport = writeReport(child, "detekt.xml")
+        val mergedReport = writeReport(root, "merge.xml")
+        val htmlReport = writeReport(root, "detekt.html")
+
+        val mergeTask = root.tasks.getByName("detektReportMergeXml") as ReportMergeTask
+
+        assertThat(mergeTask.input.files)
+            .contains(rootReport, rootKmpReport, childReport)
+            .doesNotContain(mergedReport, htmlReport)
+    }
+
+    private fun writeReport(project: Project, name: String): File {
+        val file = project.layout.buildDirectory.file("reports/detekt/$name").get().asFile
+        file.parentFile.mkdirs()
+        file.writeText("<checkstyle version=\"4.3\"/>")
+        return file
     }
 
     @Test

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/SonarQubeConfiguratorTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/SonarQubeConfiguratorTest.kt
@@ -3,6 +3,7 @@ package io.komune.fixers.gradle.check
 import io.komune.fixers.gradle.config.model.Bundle
 import io.komune.fixers.gradle.config.model.Sonar
 import io.komune.fixers.gradle.plugin.check.SonarQubeConfigurator
+import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -106,6 +107,76 @@ class SonarQubeConfiguratorTest {
                 .isNotNull
                 .asString()
                 .contains("merge.xml")
+        }
+
+        @Test
+        fun `should make detekt report path absolute so every module resolves the root merged report`() {
+            val sonar = Sonar(project)
+
+            val properties = configurator.buildSonarProperties(sonar, null)
+
+            val detektPath = properties["sonar.kotlin.detekt.reportPaths"] as String
+            assertThat(File(detektPath).isAbsolute).isTrue()
+            assertThat(detektPath).isEqualTo(
+                File(project.rootDir, "build/reports/detekt/merge.xml").path
+            )
+        }
+
+        @Test
+        fun `should resolve detekt report path of a subproject against the root project`() {
+            val subproject = ProjectBuilder.builder().withParent(project).withName("sub").build()
+            val subConfigurator = SonarQubeConfigurator(subproject)
+
+            val properties = subConfigurator.buildSonarProperties(Sonar(subproject), null)
+
+            // The merged report only exists in the root build directory: a path relative to the
+            // subproject would make Sonar log "Unable to import detekt report file(s)".
+            assertThat(properties["sonar.kotlin.detekt.reportPaths"]).isEqualTo(
+                File(project.rootDir, "build/reports/detekt/merge.xml").path
+            )
+        }
+
+        @Test
+        fun `should keep an absolute detekt report path unchanged`() {
+            val absolutePath = File(System.getProperty("java.io.tmpdir"), "custom/detekt.xml").path
+            val sonar = Sonar(project).apply { detekt.set(absolutePath) }
+
+            val properties = configurator.buildSonarProperties(sonar, null)
+
+            assertThat(properties["sonar.kotlin.detekt.reportPaths"]).isEqualTo(absolutePath)
+        }
+
+        @Test
+        fun `should resolve every entry of a comma separated detekt report path`() {
+            val sonar = Sonar(project).apply {
+                detekt.set("build/reports/detekt/merge.xml, build/reports/detekt/detekt.xml")
+            }
+
+            val properties = configurator.buildSonarProperties(sonar, null)
+
+            assertThat(properties["sonar.kotlin.detekt.reportPaths"]).isEqualTo(
+                listOf("build/reports/detekt/merge.xml", "build/reports/detekt/detekt.xml")
+                    .joinToString(",") { File(project.rootDir, it).path }
+            )
+        }
+
+        @Test
+        fun `should match jacoco reports of both the jvm and the multiplatform layout`() {
+            val sonar = Sonar(project)
+            val pattern = configurator.buildSonarProperties(sonar, null)["sonar.coverage.jacoco.xmlReportPaths"] as String
+
+            // Reproduces how Sonar resolves the pattern: relative to the base directory of each
+            // module, with an Ant-style matcher where "**/" also matches zero directories.
+            val moduleDir = project.projectDir
+            listOf("test", "jvmTest").forEach { testTaskDir ->
+                val report = File(moduleDir, "build/reports/jacoco/$testTaskDir/jacocoTestReport.xml")
+                report.parentFile.mkdirs()
+                report.writeText("<report/>")
+            }
+
+            val matched = project.fileTree(moduleDir).matching { include(pattern) }.files.map { it.name }
+
+            assertThat(matched).hasSize(2).containsOnly("jacocoTestReport.xml")
         }
 
         @Test

--- a/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/check/CheckPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/check/CheckPluginIntegrationTest.kt
@@ -572,6 +572,68 @@ class CheckPluginIntegrationTest : BaseIntegrationTest() {
         }
 
         /**
+         * Test that the Detekt report path handed to the scanner is absolute in every module:
+         * Sonar resolves relative report paths against the base directory of each analysed module,
+         * where the merged report - written in the root build directory - does not exist.
+         */
+        @Test
+        fun `should hand an absolute detekt report path to every module`() {
+            settingsFile.writeText("""
+                rootProject.name = "integration-test-project"
+                include("subproject")
+            """.trimIndent())
+
+            val subprojectDir = testProjectDir.resolve("subproject").toFile()
+            subprojectDir.mkdirs()
+            File(subprojectDir, "build.gradle.kts").writeText("""
+                plugins {
+                    kotlin("jvm")
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                tasks.register("verifyModuleDetektPath") {
+                    doLast {
+                        val config = rootProject.extensions.getByName("fixers")
+                            as io.komune.fixers.gradle.config.ConfigExtension
+                        val properties = io.komune.fixers.gradle.plugin.check.SonarQubeConfigurator(project)
+                            .buildSonarProperties(config.sonar, null)
+                        val detektPath = properties["sonar.kotlin.detekt.reportPaths"].toString()
+                        val expected = rootProject.rootDir.resolve("build/reports/detekt/merge.xml").path
+                        println("Module detekt path: ${'$'}detektPath")
+                        println("Module detekt path is the root merged report: ${'$'}{detektPath == expected}")
+                    }
+                }
+            """.trimIndent())
+
+            writeBuildFile("""
+                plugins {
+                    kotlin("jvm") version "${getCompatibleKotlinVersion(null)}"
+                    id("io.komune.fixers.gradle.config")
+                    id("io.komune.fixers.gradle.check")
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                fixers {
+                    sonar {
+                        projectKey = "test-project"
+                        organization = "test-org"
+                    }
+                }
+            """.trimIndent())
+
+            val result = runGradle(":subproject:verifyModuleDetektPath")
+
+            assertThat(result.task(":subproject:verifyModuleDetektPath")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(result.output).contains("Module detekt path is the root merged report: true")
+        }
+
+        /**
          * Test that all Sonar configuration properties can be customized.
          */
         @Test


### PR DESCRIPTION
Closes #219

## What was broken

`sonar.kotlin.detekt.reportPaths` was set to the **relative** path `build/reports/detekt/merge.xml`. Sonar resolves relative report paths against the base directory of **each analysed module**, but `detektReportMergeXml` writes the merged report into the **root** project's build directory. So every module looked for `<module>/build/reports/detekt/merge.xml`, which never exists.

On [fixers-f2 PR #137's analysis](https://github.com/komune-io/fixers-f2/actions/runs/31597627478) that produced 28 `Unable to import detekt report file(s)` warnings — one per module with Kotlin sources — and the import succeeded nowhere: the root project has no Kotlin sources, so the Detekt sensor never runs there. **No Detekt finding has ever been imported into SonarCloud in any consumer repo.**

Secondary defect: `DetektConfiguration` forced *every* `Detekt` task of a project to write to the same `detekt.xml` / `detekt.sarif`, and fed only that one path into the merge tasks. Kotlin Multiplatform registers one Detekt task per source set and per compilation, so whenever more than one runs they overwrite each other's report and the merge keeps only the last.

## What changed

* `SonarQubeConfigurator.resolveDetektReportPaths` resolves relative detekt report paths against the root project directory (absolute paths are passed through untouched, comma-separated lists are handled entry by entry), so every module points at the single merged report.
* Detekt reports are named after the task producing them (`build/reports/detekt/<taskName>.xml|.sarif`); the default `detekt` task keeps `detekt.xml`, so nothing moves for JVM-only projects.
* `detektReportMergeXml` / `detektReportMergeSarif` now take every `*.xml` / `*.sarif` of each project's `build/reports/detekt` (excluding the merged files themselves) instead of the single hard-coded `detekt.xml`.
* Kdoc on `Sonar.detekt` / `Sonar.jacoco` documents how Sonar resolves each of them.

## Verified, and deliberately left alone

* **JaCoCo is not broken.** `**/build/reports/jacoco/**/jacocoTestReport.xml` matches both `build/reports/jacoco/test/` (JVM) and `build/reports/jacoco/jvmTest/` (KMP) — Sonar's Ant-style matcher lets `**/` match zero directories. KMP module coverage *is* reaching SonarCloud today (`commonMain`/`jvmMain` files of `f2-dsl-*` and `f2-client-*` all carry coverage on `komune-io_fixers-f2`).
* The `No coverage report can be found …` lines are informational and come from modules that genuinely produce no coverage report (no tests) plus aggregator projects. They cannot be suppressed from the plugin.
* The empty root `merge.xml` is simply "zero findings", not a broken merge.

## Follow-up, not in this PR

Detekt never analyses Kotlin Multiplatform source sets: in fixers-f2 CI `:f2-dsl:f2-dsl-function:detekt`, `:f2-client:f2-client-ktor:detekt` … are all `NO-SOURCE`. Wiring the KMP source-set tasks into `detekt` will surface new findings and can fail consumer builds, so it deserves its own change. Tracked in the "Known follow-up" section of #219.

No consumer-repo change is required for this fix.

## Tests

* `SonarQubeConfiguratorTest`: detekt path is absolute, is the root merged report when built from a subproject, keeps absolute values, resolves every entry of a comma-separated list; jacoco pattern matches both the `test/` and `jvmTest/` layouts (Ant matcher, real files on disk).
* `DetektConfigurationTest`: per-task report naming produces distinct outputs; the XML merge collects reports from every project, including non-default task names, and excludes the merged files.
* `CheckPluginIntegrationTest`: a subproject of a multi-project build receives the root merged report as an absolute path.
* `./gradlew :build-composite:test :plugin:test detekt` — 582 tests, 0 failures.
* End-to-end on this repo: planting `config/build/reports/detekt/detektFakeSourceSet.xml` and running `:detektReportMergeXml` merges it into the root `merge.xml`; the previous wiring ignored anything not named `detekt.xml`.

_Found while reviewing Sonar warnings on fixers-f2 PR #137._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Detekt reports from overwriting one another by assigning task-specific filenames.
  - Improved merging of Detekt reports across multi-module projects while excluding already merged outputs.
  - Ensured SonarQube receives correctly resolved absolute paths for Detekt reports.
  - Improved JaCoCo report matching across JVM and Kotlin Multiplatform layouts.

- **Documentation**
  - Clarified JaCoCo matching and Detekt report resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->