### PR TITLE
fix: repair main compilation broken by #215/#220 semantic conflict

### DIFF
--- a/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/check/CheckPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/komune/fixers/gradle/integration/check/CheckPluginIntegrationTest.kt
@@ -610,7 +610,7 @@ class CheckPluginIntegrationTest : BaseIntegrationTest() {
 
             writeBuildFile("""
                 plugins {
-                    kotlin("jvm") version "${getCompatibleKotlinVersion(null)}"
+                    kotlin("jvm") version "$TEST_KOTLIN_VERSION"
                     id("io.komune.fixers.gradle.config")
                     id("io.komune.fixers.gradle.check")
                 }


### PR DESCRIPTION
Main's `Dev` workflow is red since #215 merged: `CheckPluginIntegrationTest.kt:613` references `getCompatibleKotlinVersion`, which #220 introduced a call to and #215 deleted (collapsed into `TEST_KOTLIN_VERSION`). The two PRs were each green against the main they were tested on — classic semantic merge conflict.

One-line fix aligning line 613 with the 4 other call sites in the same file that already use `TEST_KOTLIN_VERSION`.

Verified: `./gradlew :plugin:compileTestKotlin` BUILD SUCCESSFUL.

This also unblocks the 7 Dependabot PRs (#221–#227), which all fail on this same compile error via their merge commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Sonar Detekt integration test to use the standard Kotlin test version configuration.
  * Improved test consistency without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->