### PR TITLE
docs: include the S7637 suppression in the reusable's caller template

### DIFF
--- a/.github/workflows/dependabot-verification-workflow.yml
+++ b/.github/workflows/dependabot-verification-workflow.yml
@@ -22,7 +22,15 @@ name: Dependabot Verification Metadata
 #     pull-requests: write
 #   jobs:
 #     regenerate:
-#       uses: komune-io/fixers-gradle/.github/workflows/dependabot-verification-workflow.yml@main
+#       # Org-internal reusable, deliberately tracked @main like every komune-io
+#       # workflow reference: central fixes must propagate to all callers
+#       # without a pin-bump wave.
+#       uses: komune-io/fixers-gradle/.github/workflows/dependabot-verification-workflow.yml@main # NOSONAR(githubactions:S7637)
+#
+# The NOSONAR marker suppresses SonarCloud's githubactions:S7637 ("use full
+# commit SHA"), which fails the new-code security gate on any new caller file;
+# Codacy's semgrep twin of the rule may need its own nosemgrep marker if the
+# caller repo runs it.
 #
 # Safety model (why pull_request_target is acceptable here):
 #   - the job is gated to actor == dependabot[bot] and same-repo head branches,


### PR DESCRIPTION
Comment-only. fixers-c2#135's thin caller failed the SonarCloud new-code security gate on `githubactions:S7637` (SHA-pin the `uses:` reference) — a rule every future caller file will trip, since the `@main` reference to this org-internal reusable is deliberate (central fixes must reach all callers without a pin-bump wave).

Updates the minimal-caller template in the header to ship the `# NOSONAR(githubactions:S7637)` marker with its rationale, plus a note about Codacy's semgrep twin, so f2/s2/gradle callers copy the working form from day one instead of rediscovering the gate failure.