### PR TITLE
ci: never cancel PR runs that can publish (stage label, versioning/*)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,11 +11,13 @@ on:
       - main
       - 'release/*'
 
-# Only cancel superseded pull request runs. Pushes to main, release branches and
-# scheduled runs queue instead, so a publish is never interrupted mid-flight.
+# Cancel only superseded pull request runs that cannot publish: PRs labeled
+# 'stage' and versioning/* release PRs run the stage task, so they queue —
+# like pushes, scheduled and manually dispatched runs — instead of being
+# cancelled mid-publish.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'stage') && !startsWith(github.head_ref, 'versioning/') }}
 
 jobs:
   dev:


### PR DESCRIPTION
Follow-up to #210, from CodeRabbit review on [fixers-s2#120](https://github.com/komune-io/fixers-s2/pull/120): the make-jvm-workflow stage step also runs on PRs **labeled `stage`** and on **`versioning/*` release PRs** — so cancelling any superseded PR run could interrupt a publish mid-flight during a release. The cancel predicate now excludes exactly those two cases, mirroring the stage step's own condition, and the comment states the real behavior (including queued manual dispatches).