### PR TITLE
ci: authenticate Dependabot regen against GitHub Packages (read-only token)

### DIFF
--- a/.github/workflows/dependabot-verification-workflow.yml
+++ b/.github/workflows/dependabot-verification-workflow.yml
@@ -20,6 +20,7 @@ name: Dependabot Verification Metadata
 #     contents: write
 #     actions: write
 #     pull-requests: write
+#     packages: read
 #   jobs:
 #     regenerate:
 #       # Org-internal reusable, deliberately tracked @main like every komune-io
@@ -79,6 +80,14 @@ jobs:
       github.actor == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Downgraded token: the regen resolves io.komune snapshots from GitHub
+    # Packages, which requires authentication even for public packages. With
+    # contents/packages read-only, exposing this job's token to the untrusted
+    # build is acceptable — it can read, never write. The write token still
+    # exists only in the push job.
+    permissions:
+      contents: read
+      packages: read
     outputs:
       changed: ${{ steps.delta.outputs.changed }}
     steps:
@@ -95,6 +104,10 @@ jobs:
           with-gradle-build-scan-publish: false
 
       - name: Regenerate verification metadata
+        env:
+          # read by the init script from setup-gradle-github-pkg for maven.pkg.github.com
+          FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+          FIXERS_PUBLISH_GITHUB_TOKEN: ${{ github.token }}
         run: make -f ${{ inputs.make-file }} ${{ inputs.regen-task }}
 
       - name: Detect changes
@@ -126,6 +139,10 @@ jobs:
     needs: regenerate
     if: needs.regenerate.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/dependabot-verification.yml
+++ b/.github/workflows/dependabot-verification.yml
@@ -18,6 +18,7 @@ permissions:
   contents: write
   actions: write
   pull-requests: write
+  packages: read
 
 jobs:
   regenerate:


### PR DESCRIPTION
The first live run of the auto-regen workflow ([fixers-s2#84](https://github.com/komune-io/fixers-s2/pull/84), run 31793309816) failed: `Could not get resource 'https://maven.pkg.github.com/komune-io/fixers/...f2-dsl-cqrs-js...klib' — Username must not be null!`. GitHub Packages requires authentication even for public artifacts, and the regenerate job deliberately runs with no credentials (#234's token isolation).

**Fix preserving the isolation model**: the regenerate job declares `permissions: {contents: read, packages: read}` — a *downgraded* token — and feeds `github.actor`/`github.token` to the regen step as the `FIXERS_PUBLISH_GITHUB_*` variables the org's `setup-gradle-github-pkg` init script already reads. Exposing a read-only token to the untrusted build is acceptable (worst case: reads); the write token remains exclusive to the push job, which now declares its exact permission set too.

**Callers must add `packages: read`** to their permissions block (a reusable job can only downgrade what the caller granted) — this repo's caller updated here; f2/s2/c2 follow in sibling PRs. Template in the header updated.

**Residual uncertainty, stated plainly**: whether the repo-scoped `GITHUB_TOKEN` of e.g. fixers-s2 can read public packages homed in `komune-io/fixers` cross-repo. Normal CI uses an org PAT, which proves nothing about `GITHUB_TOKEN`. The next live test on s2#84 settles it; if it fails, the fallback is passing a narrowly-scoped org secret instead.