### PR TITLE
ci: push regen metadata with an optional PAT so PR CI re-runs correctly

### DIFF
--- a/.github/workflows/dependabot-verification-workflow.yml
+++ b/.github/workflows/dependabot-verification-workflow.yml
@@ -41,7 +41,9 @@ name: Dependabot Verification Metadata
 # (trust-on-first-use, same model as the original generation).
 # Operational notes:
 #   - pushes made with GITHUB_TOKEN do not trigger workflows, hence the explicit
-#     dispatch of the caller's CI — this same property makes loops impossible;
+#     re-run of the PR's CI (a rerun, not a dispatch: dispatch loses PR context
+#     and Sonar then reports against the default branch) — this same property
+#     makes loops impossible;
 #   - after this pushes, Dependabot refuses `@dependabot rebase`; use
 #     `@dependabot recreate`.
 
@@ -59,7 +61,7 @@ on:
         type: string
         default: "verify-metadata"
       dispatch-workflow:
-        description: "Workflow file to dispatch on the branch after pushing (must have workflow_dispatch)"
+        description: "Workflow whose latest pull_request run is re-run after pushing (rerun re-resolves the PR merge ref, preserving PR context for SonarCloud decoration)"
         required: false
         type: string
         default: "dev.yml"
@@ -166,11 +168,27 @@ jobs:
           git commit -m "build: regenerate dependency verification metadata for dependabot bump"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:$HEAD_REF"
 
-      - name: Re-trigger CI on the updated branch
+      # Re-run the PR's own pull_request run rather than dispatching the workflow
+      # on the branch: a workflow_dispatch run has no PR context, so the Sonar
+      # scanner would attribute its analysis to the DEFAULT branch (observed:
+      # polluted main dashboard + a quality-gate check on the PR that linked to
+      # main). A rerun re-resolves refs/pull/N/merge against the pushed commit
+      # and keeps every context-dependent tool pointed at the PR.
+      - name: Re-run the PR's CI on the updated merge ref
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: gh workflow run ${{ inputs.dispatch-workflow }} --ref "$HEAD_REF" -R "${{ github.repository }}"
+        run: |
+          run_id=$(gh run list -R "${{ github.repository }}" \
+            --workflow "${{ inputs.dispatch-workflow }}" \
+            --event pull_request \
+            --branch "$HEAD_REF" \
+            --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          if [ -n "$run_id" ]; then
+            gh run rerun "$run_id" -R "${{ github.repository }}"
+          else
+            echo "No pull_request run found for $HEAD_REF - skipping re-trigger (the next PR event will build the new head)."
+          fi
 
       - name: Explain on the PR
         env:

--- a/.github/workflows/dependabot-verification-workflow.yml
+++ b/.github/workflows/dependabot-verification-workflow.yml
@@ -23,6 +23,8 @@ name: Dependabot Verification Metadata
 #     packages: read
 #   jobs:
 #     regenerate:
+#       secrets:
+#         push-token: ${{ secrets.DEPENDABOT_REGEN_PUSH_TOKEN }}
 #       # Org-internal reusable, deliberately tracked @main like every komune-io
 #       # workflow reference: central fixes must propagate to all callers
 #       # without a pin-bump wave.
@@ -40,10 +42,15 @@ name: Dependabot Verification Metadata
 # Trust caveat: the regen pins what the repositories serve at PR time
 # (trust-on-first-use, same model as the original generation).
 # Operational notes:
-#   - pushes made with GITHUB_TOKEN do not trigger workflows, hence the explicit
-#     re-run of the PR's CI (a rerun, not a dispatch: dispatch loses PR context
-#     and Sonar then reports against the default branch) — this same property
-#     makes loops impossible;
+#   - pushes made with GITHUB_TOKEN do not trigger workflows, and neither a
+#     rerun (uses the ORIGINAL merge SHA per GitHub docs) nor a dispatch (loses
+#     PR context; Sonar then reports against the default branch) can produce a
+#     correct fresh run. The push therefore uses the optional push-token secret
+#     (a fine-grained PAT with contents:write): a PAT push triggers a normal
+#     pull_request run with full PR context. The synchronize event also re-fires
+#     this workflow, which finds zero delta and no-ops — no loop. Without the
+#     secret, the push falls back to GITHUB_TOKEN and the PR comment explains
+#     that checks will not re-run automatically;
 #   - after this pushes, Dependabot refuses `@dependabot rebase`; use
 #     `@dependabot recreate`.
 
@@ -70,6 +77,10 @@ on:
         required: false
         type: string
         default: "17"
+    secrets:
+      push-token:
+        description: "Fine-grained PAT (contents:write) used to push the metadata commit so that a normal pull_request run triggers. Falls back to GITHUB_TOKEN (no automatic CI re-run) when absent."
+        required: false
 
 jobs:
   # Job 1 — runs the untrusted build. No token anywhere: not on disk
@@ -158,41 +169,35 @@ jobs:
           path: gradle/
 
       - name: Commit and push metadata
+        id: push
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          GH_TOKEN: ${{ github.token }}
+          PUSH_TOKEN: ${{ secrets.push-token }}
+          FALLBACK_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add gradle/verification-metadata.xml gradle/verification-keyring.keys gradle/verification-keyring.gpg
           git commit -m "build: regenerate dependency verification metadata for dependabot bump"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:$HEAD_REF"
-
-      # Re-run the PR's own pull_request run rather than dispatching the workflow
-      # on the branch: a workflow_dispatch run has no PR context, so the Sonar
-      # scanner would attribute its analysis to the DEFAULT branch (observed:
-      # polluted main dashboard + a quality-gate check on the PR that linked to
-      # main). A rerun re-resolves refs/pull/N/merge against the pushed commit
-      # and keeps every context-dependent tool pointed at the PR.
-      - name: Re-run the PR's CI on the updated merge ref
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          run_id=$(gh run list -R "${{ github.repository }}" \
-            --workflow "${{ inputs.dispatch-workflow }}" \
-            --event pull_request \
-            --branch "$HEAD_REF" \
-            --limit 1 --json databaseId --jq '.[0].databaseId // empty')
-          if [ -n "$run_id" ]; then
-            gh run rerun "$run_id" -R "${{ github.repository }}"
+          if [ -n "$PUSH_TOKEN" ]; then
+            # PAT push: triggers a normal pull_request run with full PR context
+            git push "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:$HEAD_REF"
+            echo "auto_ci=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No pull_request run found for $HEAD_REF - skipping re-trigger (the next PR event will build the new head)."
+            # GITHUB_TOKEN push: no workflow will trigger; the PR comment explains
+            git push "https://x-access-token:${FALLBACK_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:$HEAD_REF"
+            echo "auto_ci=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Explain on the PR
         env:
           GH_TOKEN: ${{ github.token }}
+          AUTO_CI: ${{ steps.push.outputs.auto_ci }}
         run: |
+          if [ "$AUTO_CI" = "true" ]; then
+            note="CI re-runs automatically on the new commit."
+          else
+            note="No push-token secret is configured, so checks will NOT re-run automatically on the new commit (GITHUB_TOKEN pushes trigger no workflows, and a rerun of the old check would build the stale merge commit). Configure the DEPENDABOT_REGEN_PUSH_TOKEN secret, or verify locally before merging."
+          fi
           gh pr comment "${{ github.event.pull_request.number }}" -R "${{ github.repository }}" --body \
-          "Dependency verification metadata regenerated and committed for this bump; a fresh CI run was dispatched on the branch. Review the metadata delta before merging. Note: with this extra commit, \`@dependabot rebase\` will be refused — use \`@dependabot recreate\` if the PR needs rebuilding."
+          "Dependency verification metadata regenerated and committed for this bump. $note Review the metadata delta before merging. Note: with this extra commit, \`@dependabot rebase\` will be refused — use \`@dependabot recreate\` if the PR needs rebuilding."

--- a/.github/workflows/dependabot-verification-workflow.yml
+++ b/.github/workflows/dependabot-verification-workflow.yml
@@ -49,8 +49,9 @@ name: Dependabot Verification Metadata
 #     (a fine-grained PAT with contents:write): a PAT push triggers a normal
 #     pull_request run with full PR context. The synchronize event also re-fires
 #     this workflow, which finds zero delta and no-ops — no loop. Without the
-#     secret, the push falls back to GITHUB_TOKEN and the PR comment explains
-#     that checks will not re-run automatically;
+#     secret, the push falls back to GITHUB_TOKEN and the PR comment tells the
+#     reviewer to add any label — dev.yml listens to `labeled`, and a human
+#     label event triggers a genuine fresh pull_request run;
 #   - after this pushes, Dependabot refuses `@dependabot rebase`; use
 #     `@dependabot recreate`.
 
@@ -197,7 +198,7 @@ jobs:
           if [ "$AUTO_CI" = "true" ]; then
             note="CI re-runs automatically on the new commit."
           else
-            note="No push-token secret is configured, so checks will NOT re-run automatically on the new commit (GITHUB_TOKEN pushes trigger no workflows, and a rerun of the old check would build the stale merge commit). Configure the DEPENDABOT_REGEN_PUSH_TOKEN secret, or verify locally before merging."
+            note="Checks do NOT re-run automatically on this commit (GITHUB_TOKEN pushes trigger no workflows, and re-running the old check would build the stale merge commit). To re-run them: **add any label to this PR** — a human label event triggers a fresh pull_request run with the new metadata. (Optional alternative for full automation: configure the push-token secret.)"
           fi
           gh pr comment "${{ github.event.pull_request.number }}" -R "${{ github.repository }}" --body \
           "Dependency verification metadata regenerated and committed for this bump. $note Review the metadata delta before merging. Note: with this extra commit, \`@dependabot rebase\` will be refused — use \`@dependabot recreate\` if the PR needs rebuilding."


### PR DESCRIPTION
**Supersedes the rerun approach this PR originally proposed — review of the full process (prompted by Adrien) disproved it.**

Live evidence, in order:
1. **Dispatch** (current main): builds the right code but has no PR context → the Sonar scanner attributed the branch analysis to **main** (observed on s2#84: polluted dashboard, PR check linking to main's C gate).
2. **Rerun** (this PR's first version): GitHub reruns use the **original merge SHA** — it would rebuild the pre-metadata code. My cited evidence (c2#129's docker rerun) was a transient-flake retry, not proof of merge-ref re-resolution. Withdrawn.
3. **Approving the held bot-push run**: the `action_required` run observed at 12:02:27 on s2#84 was **garbage-collected** — it no longer exists. Not a dependable mechanism.
4. **`@dependabot recreate` as recovery**: discards the metadata commit and re-fires regen — a cycle that never ends green.

**The one correct mechanism** is the industry-standard one: push the metadata commit with a **fine-grained PAT** (`push-token` optional secret). A PAT push triggers a normal `pull_request` run on the fresh merge ref with full PR context — correct checks, correct Sonar decoration, no explicit re-trigger step at all. The synchronize event re-fires this regen workflow, which finds zero delta and no-ops (loop-safe).

**Fallback without the secret**: push with `GITHUB_TOKEN` as today, and the PR comment states plainly that checks will not re-run automatically and why.

**Setup required** (one-time, org level): create a fine-grained PAT with **contents: read/write** on fixers-gradle/f2/s2/c2, store as org secret `DEPENDABOT_REGEN_PUSH_TOKEN`, and pass it from each caller (template in the header updated):
```yaml
    secrets:
      push-token: ${{ secrets.DEPENDABOT_REGEN_PUSH_TOKEN }}
```
Security note: the PAT lives exclusively in the `push` job — the untrusted regen build never sees it, same isolation as #234.