### PR TITLE
chore: tier 1 dead-config cleanup

### DIFF
--- a/.github/workflows/sec-workflow.yml
+++ b/.github/workflows/sec-workflow.yml
@@ -111,22 +111,3 @@ jobs:
         timeout-minutes: 5
         env:
           SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
-
-#  codacy-analysis:
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: read
-#      security-events: write
-#    steps:
-#      - uses: actions/checkout@v7
-#      - name: Run Codacy Analysis
-#        uses: codacy/codacy-analysis-cli-action@v4
-#        with:
-#          output: results.sarif
-#          format: sarif
-#          gh-code-scanning-compat: true
-#          max-allowed-issues: 2147483647
-#      - name: Upload SARIF File to GitHub Code Scanning
-#        uses: github/codeql-action/upload-sarif@v4
-#        with:
-#          sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .env
 
 config/src/main/kotlin/io/komune/fixers/gradle/config
-dependencies/src/main/kotlin/io/komune/fixers/gradle/dependencies
 plugin/src/main/kotlin/io/komune/fixers/gradle/plugin
 
 ### STS ###

--- a/build-composite/build.gradle.kts
+++ b/build-composite/build.gradle.kts
@@ -63,7 +63,6 @@ tasks.test {
     environment("PROPERTY_UTILS_TEST_STRING", "env-value")
     environment("PROPERTY_UTILS_TEST_INT", "42")
     environment("PROPERTY_UTILS_TEST_BOOL", "true")
-    environment("PROPERTY_UTILS_TEST_LIST", "a, b ,c")
     testLogging {
         events("passed", "skipped", "failed")
     }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/ConfigExtension.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/ConfigExtension.kt
@@ -14,7 +14,6 @@ import io.komune.fixers.gradle.config.model.sonarCloud
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionContainer
-import org.gradle.api.provider.Property
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
@@ -30,15 +29,6 @@ val ExtensionContainer.fixers: ConfigExtension?
  */
 fun Project.fixers(configure: Action<ConfigExtension>): Unit =
 	this.rootProject.extensions.configure(ConfigExtension.NAME, configure)
-
-/**
- * Configures the [fixers][io.komune.fixers.gradle.config.ConfigExtension.NAME] extension if exists.
- */
-fun ExtensionContainer.fixersIfExists(configure: Action<ConfigExtension>) {
-	if (fixers != null) {
-		configure(ConfigExtension.NAME, configure)
-	}
-}
 
 fun PluginDependenciesSpec.fixers(module: String): PluginDependencySpec = id("io.komune.fixers.gradle.${module}")
 
@@ -57,8 +47,6 @@ abstract class ConfigExtension(
 		const val NAME: String = "fixers"
 	}
 
-	var properties: MutableMap<String, Any> = mutableMapOf()
-
 	var bundle: Bundle = Bundle(
 		project = project,
 		name = project.name
@@ -67,14 +55,6 @@ abstract class ConfigExtension(
 	var kt2Ts: Kt2Ts = Kt2Ts(project)
 
 	var jdk: Jdk = Jdk(project)
-
-	/**
-	 * Build time as a lazy Provider for configuration cache compatibility.
-	 * The timestamp is captured when the value is first accessed, not at configuration time.
-	 */
-	val buildTime: Property<Long> = project.objects.property(Long::class.java).convention(
-		project.provider { System.currentTimeMillis() }
-	)
 
 	var pom: Publication = Publication(project)
 
@@ -136,7 +116,6 @@ abstract class ConfigExtension(
 			bundle=$bundle,
 			kt2Ts=$kt2Ts,
 			jdk=$jdk,
-			buildTime=$buildTime,
 			publication=$pom,
 			npm=$npm,
 			detekt=$detekt,

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/Jacoco.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/Jacoco.kt
@@ -1,6 +1,5 @@
 package io.komune.fixers.gradle.config.model
 
-import io.komune.fixers.gradle.config.utils.mergeIfNotPresent
 import io.komune.fixers.gradle.config.utils.property
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -55,23 +54,6 @@ class Jacoco(
         projectKey = "fixers.jacoco.version",
         defaultValue = FixersToolVersions.jacoco
     )
-
-    /**
-     * Merges properties from the source Jacoco into this Jacoco.
-     * Properties are only merged if the target property is not present and the source property is present.
-     *
-     * @param source The source Jacoco to merge from
-     * @return This Jacoco after merging
-     */
-    fun mergeFrom(source: Jacoco): Jacoco {
-        enabled.mergeIfNotPresent(source.enabled)
-        htmlReport.mergeIfNotPresent(source.htmlReport)
-        xmlReport.mergeIfNotPresent(source.xmlReport)
-        xmlReportFilename.mergeIfNotPresent(source.xmlReportFilename)
-        version.mergeIfNotPresent(source.version)
-
-        return this
-    }
 
     companion object {
         const val DEFAULT_XML_REPORT_FILENAME = "jacocoTestReport.xml"

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/utils/PropertyUtils.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/utils/PropertyUtils.kt
@@ -4,7 +4,6 @@ import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
 
 /**
@@ -69,48 +68,6 @@ inline fun <reified T> Property<T>.extractEnv(envValue: String) where T : Any {
     }
     convention(value)
     return
-}
-
-/**
- * Initializes a list property from environment variables, project properties, and a default value.
- * Priority: 1. kts file dsl (handled by convention() in the calling code)
- *          2. ENV system properties (comma-separated values)
- *          3. Project properties (comma-separated values)
- *          4. Default value
- *
- * Uses providers.environmentVariable() for configuration cache compatibility.
- *
- * @param envKey The environment variable key to check for a value
- * @param projectKey The project property key to check for a value
- * @param defaultValue The default value to use if no other value is found
- * @return A ListProperty<T> initialized with the appropriate values
- */
-inline fun <reified T> Project.initListProperty(
-    envKey: String? = null,
-    projectKey: String? = null,
-    defaultValue: List<T>? = null
-): ListProperty<T> where T : Any {
-    return objects.listProperty<T>().apply {
-        if (envKey != null) {
-            providers.environmentVariable(envKey).orNull?.let { envValue ->
-                val list = envValue.split(",").map { it.trim() as T }
-                convention(list)
-                return@apply
-            }
-        }
-
-        if (projectKey != null) {
-            findProperty(projectKey)?.toString()?.let { projValue ->
-                val list = projValue.split(",").map { it.trim() as T }
-                convention(list)
-                return@apply
-            }
-        }
-
-        if (defaultValue != null) {
-            convention(defaultValue)
-        }
-    }
 }
 
 /**

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/JacocoConfigurator.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/check/JacocoConfigurator.kt
@@ -24,8 +24,7 @@ class JacocoConfigurator(
      * @param jacocoConfig The JaCoCo configuration settings
      */
     fun configure(jacocoConfig: Jacoco?) {
-        val jacocoEnabled = jacocoConfig?.enabled?.getOrElse(true) ?: true
-        if (!jacocoEnabled) {
+        if (!isEnabled(jacocoConfig)) {
             return
         }
 
@@ -65,10 +64,10 @@ class JacocoConfigurator(
      */
     fun configureJacocoReportTasks(jacocoConfig: Jacoco?) {
         project.tasks.withType<JacocoReport>().configureEach {
-            isEnabled = jacocoConfig?.enabled?.getOrElse(true) ?: true
+            isEnabled = isEnabled(jacocoConfig)
             reports {
-                html.required.set(jacocoConfig?.htmlReport?.getOrElse(true) ?: true)
-                xml.required.set(jacocoConfig?.xmlReport?.getOrElse(true) ?: true)
+                html.required.set(isHtmlReportEnabled(jacocoConfig))
+                xml.required.set(isXmlReportEnabled(jacocoConfig))
             }
         }
     }
@@ -84,7 +83,7 @@ class JacocoConfigurator(
         project.tasks.matching { it.name == "jvmTest" }.configureEach {
             if (this is Test) {
                 extensions.configure(JacocoTaskExtension::class.java) {
-                    isEnabled = jacocoConfig?.enabled?.getOrElse(true) ?: true
+                    isEnabled = isEnabled(jacocoConfig)
                 }
             }
         }
@@ -95,7 +94,7 @@ class JacocoConfigurator(
         (project.tasks.findByName("jvmTest") as? Test)?.let { jvmTestTask ->
             project.tasks.register<JacocoReport>("jacocoJvmTestReport") {
                 dependsOn(jvmTestTask)
-                isEnabled = jacocoConfig?.enabled?.getOrElse(true) ?: true
+                isEnabled = isEnabled(jacocoConfig)
 
                 val jvmCompilation = jvmTarget.compilations.getByName("main")
                 classDirectories.setFrom(jvmCompilation.output.classesDirs)
@@ -104,12 +103,10 @@ class JacocoConfigurator(
                 )
                 executionData.setFrom(project.layout.buildDirectory.file("jacoco/jvmTest.exec"))
 
-                val xmlFilename = jacocoConfig?.xmlReportFilename
-                    ?.getOrElse(Jacoco.DEFAULT_XML_REPORT_FILENAME)
-                    ?: Jacoco.DEFAULT_XML_REPORT_FILENAME
+                val xmlFilename = getXmlReportFilename(jacocoConfig)
                 reports {
-                    html.required.set(jacocoConfig?.htmlReport?.getOrElse(true) ?: true)
-                    xml.required.set(jacocoConfig?.xmlReport?.getOrElse(true) ?: true)
+                    html.required.set(isHtmlReportEnabled(jacocoConfig))
+                    xml.required.set(isXmlReportEnabled(jacocoConfig))
                     html.outputLocation.set(
                         project.layout.buildDirectory.dir("reports/jacoco/jvmTest/html")
                     )

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/config/ConfigPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/config/ConfigPlugin.kt
@@ -92,18 +92,18 @@ class ConfigPlugin : Plugin<Project> {
 
     private fun Project.configureRepositories(repos: Repositories) {
         val handler = repositories
-        if (repos.mavenLocal.getOrElse(false)) {
+        if (repos.mavenLocal.get()) {
             handler.mavenLocal()
         }
-        if (repos.mavenCentral.getOrElse(true)) {
+        if (repos.mavenCentral.get()) {
             handler.mavenCentral()
         }
-        if (repos.sonatypeSnapshots.getOrElse(true)) {
+        if (repos.sonatypeSnapshots.get()) {
             handler.maven(Action<MavenArtifactRepository> {
                 url = java.net.URI("https://central.sonatype.com/repository/maven-snapshots")
             })
         }
-        repos.mavenUrls.getOrElse(emptyList()).forEach { repoUrl ->
+        repos.mavenUrls.get().forEach { repoUrl ->
             handler.maven(Action<MavenArtifactRepository> {
                 url = java.net.URI(repoUrl)
             })

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/kotlin/MppJsPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/kotlin/MppJsPlugin.kt
@@ -29,10 +29,6 @@ class MppJsPlugin : Plugin<Project> {
                     configureJsOptions()
                 }
             }
-            sourceSets.getByName("jsMain") {
-                dependencies {
-                }
-            }
             sourceSets.getByName("jsTest") {
                 dependencies {
                     implementation(kotlin("test-js"))

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetup.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetup.kt
@@ -29,7 +29,7 @@ object PublishJvmSetup {
 		configure<PublishingExtension> {
 			publications.configureEach {
 				(this as? MavenPublication)?.let { mavenPublication ->
-					mavenPublication.artifactId = getArtifactId(variantName, name)
+					mavenPublication.artifactId = pluginMarkerArtifactId(variantName, name)
 					val publication = project.pom(config.bundle)
 					mavenPublication.pom(publication)
 					tasks.findByName("javadocJar")?.let { mavenPublication.artifact(it) }
@@ -40,7 +40,7 @@ object PublishJvmSetup {
 	}
 
 
-	internal fun getArtifactId(projectName: String, publicationName: String): String {
+	internal fun pluginMarkerArtifactId(projectName: String, publicationName: String): String {
 		if(publicationName.endsWith("PluginMarkerMaven")) {
 			return publicationName.replace("PluginMarkerMaven", ".gradle.plugin")
 		}

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishMppSetup.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishMppSetup.kt
@@ -34,7 +34,7 @@ object PublishMppSetup {
 		configure<PublishingExtension> {
 			publications.withType<MavenPublication>().configureEach {
 				val mavenPublication = this
-				mavenPublication.artifactId = getArtifactId(projectName, mavenPublication.name)
+				mavenPublication.artifactId = mppTargetArtifactId(projectName, mavenPublication.name)
 				val publication = project.pom(config.bundle)
 				mavenPublication.pom(publication)
 
@@ -44,7 +44,7 @@ object PublishMppSetup {
 		}
 	}
 
-	private fun getArtifactId(projectName: String, publicationName: String): String {
+	private fun mppTargetArtifactId(projectName: String, publicationName: String): String {
 		return "${projectName}${"-$publicationName".takeUnless { "kotlinMultiplatform" in publicationName }.orEmpty()}"
 	}
 

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/check/CheckPluginTest.kt
@@ -217,41 +217,6 @@ class CheckPluginTest {
             assertThat(jacoco.xmlReportFilename.get()).isEqualTo("custom-report.xml")
         }
 
-        @Test
-        fun `should not overwrite values during merge when target has values`() {
-            val source = Jacoco(project).apply {
-                enabled.set(false)
-                htmlReport.set(false)
-                xmlReport.set(false)
-                xmlReportFilename.set("source-report.xml")
-            }
-
-            val target = Jacoco(project).apply {
-                enabled.set(true)
-            }
-            target.mergeFrom(source)
-
-            // Target already has enabled set, should preserve its value
-            assertThat(target.enabled.get()).isTrue()
-        }
-
-        @Test
-        fun `should preserve explicit target values during merge`() {
-            val source = Jacoco(project).apply {
-                enabled.set(false)
-                htmlReport.set(false)
-            }
-
-            val target = Jacoco(project).apply {
-                enabled.set(true)
-                htmlReport.set(true)
-            }
-            target.mergeFrom(source)
-
-            // Both values were explicitly set on target
-            assertThat(target.enabled.get()).isTrue()
-            assertThat(target.htmlReport.get()).isTrue()
-        }
     }
 
     @Nested
@@ -525,14 +490,6 @@ class CheckPluginTest {
             }
 
             assertThat(config.detekt.disable.get()).isTrue()
-        }
-
-        @Test
-        fun `should have default buildTime provider`() {
-            val config = createConfigExtension()
-
-            val buildTime = config.buildTime.get()
-            assertThat(buildTime).isGreaterThan(0)
         }
 
         @Test

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/FixersExtensionTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/FixersExtensionTest.kt
@@ -38,19 +38,6 @@ class FixersExtensionTest {
     }
 
     @Test
-    fun `fixersIfExists should run the action only when the extension exists`() {
-        val project = ProjectBuilder.builder().build()
-        var executed = false
-
-        project.extensions.fixersIfExists { executed = true }
-        assertThat(executed).isFalse()
-
-        project.extensions.create(ConfigExtension.NAME, ConfigExtension::class.java, project)
-        project.extensions.fixersIfExists { executed = true }
-        assertThat(executed).isTrue()
-    }
-
-    @Test
     fun `PluginDependenciesSpec fixers should prefix the komune plugin id`() {
         val requestedIds = mutableListOf<String>()
         val spec = object : PluginDependenciesSpec {

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/utils/PropertyUtilsTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/utils/PropertyUtilsTest.kt
@@ -133,18 +133,6 @@ class PropertyUtilsTest {
         }
 
         @Test
-        fun `should split environment variable for list properties`() {
-            val project = projectWithProperties("fixers.test.list" to "x,y")
-
-            val property = project.initListProperty<String>(
-                envKey = "PROPERTY_UTILS_TEST_LIST",
-                projectKey = "fixers.test.list"
-            )
-
-            assertThat(property.get()).containsExactly("a", "b", "c")
-        }
-
-        @Test
         fun `should fall back to project property when env variable is missing`() {
             val project = projectWithProperties("fixers.test.value" to "from-project")
 
@@ -154,40 +142,6 @@ class PropertyUtilsTest {
             )
 
             assertThat(property.get()).isEqualTo("from-project")
-        }
-    }
-
-    @Nested
-    inner class ListPropertyTest {
-
-        @Test
-        fun `should split comma separated project property`() {
-            val project = projectWithProperties("fixers.test.list" to "a, b ,c")
-
-            val property = project.initListProperty<String>(projectKey = "fixers.test.list")
-
-            assertThat(property.get()).containsExactly("a", "b", "c")
-        }
-
-        @Test
-        fun `should use default list when nothing is configured`() {
-            val project = projectWithProperties()
-
-            val property = project.initListProperty(
-                projectKey = "fixers.test.list",
-                defaultValue = listOf("x", "y")
-            )
-
-            assertThat(property.get()).containsExactly("x", "y")
-        }
-
-        @Test
-        fun `should be empty when nothing is configured and no default given`() {
-            val project = projectWithProperties()
-
-            val property = project.initListProperty<String>(projectKey = "fixers.test.list")
-
-            assertThat(property.get()).isEmpty()
         }
     }
 }

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetupTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetupTest.kt
@@ -25,16 +25,16 @@ class PublishJvmSetupTest {
     }
 
     @Nested
-    inner class GetArtifactIdTest {
+    inner class PluginMarkerArtifactIdTest {
 
         @Test
         fun `should return project name for regular publications`() {
-            assertThat(PublishJvmSetup.getArtifactId("my-project", "maven")).isEqualTo("my-project")
+            assertThat(PublishJvmSetup.pluginMarkerArtifactId("my-project", "maven")).isEqualTo("my-project")
         }
 
         @Test
         fun `should map plugin marker publications to gradle plugin artifact id`() {
-            assertThat(PublishJvmSetup.getArtifactId("my-project", "fooPluginMarkerMaven"))
+            assertThat(PublishJvmSetup.pluginMarkerArtifactId("my-project", "fooPluginMarkerMaven"))
                 .isEqualTo("foo.gradle.plugin")
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,32 +66,16 @@ tasks.register<Delete>("cleanPluginSources") {
 
 
 gradle.projectsEvaluated {
-	project(":config") {
-		tasks.named("clean") {
-			dependsOn(rootProject.tasks.named("cleanConfigSources"))
-		}
-		tasks.named("compileKotlin") {
-			dependsOn(rootProject.tasks.named("copyConfigSources"))
-		}
-		tasks.named("sourcesJar") {
-			dependsOn(rootProject.tasks.named("copyConfigSources"))
-		}
-		tasks.named("detekt") {
-			dependsOn(rootProject.tasks.named("copyConfigSources"))
-		}
-	}
-	project(":plugin") {
-		tasks.named("clean") {
-			dependsOn(rootProject.tasks.named("cleanPluginSources"))
-		}
-		tasks.named("compileKotlin") {
-			dependsOn(rootProject.tasks.named("copyPluginSources"))
-		}
-		tasks.named("sourcesJar") {
-			dependsOn(rootProject.tasks.named("copyPluginSources"))
-		}
-		tasks.named("detekt") {
-			dependsOn(rootProject.tasks.named("copyPluginSources"))
+	mapOf(":config" to "Config", ":plugin" to "Plugin").forEach { (projectPath, sourceKind) ->
+		project(projectPath) {
+			tasks.named("clean") {
+				dependsOn(rootProject.tasks.named("clean${sourceKind}Sources"))
+			}
+			listOf("compileKotlin", "sourcesJar", "detekt").forEach { taskName ->
+				tasks.named(taskName) {
+					dependsOn(rootProject.tasks.named("copy${sourceKind}Sources"))
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Behavior-preserving cleanup — Tier 1 items 10-14 of the fixers simplification audit. All Kotlin edits made in `build-composite/` (the `config/` and `plugin/` trees are generated by the root Sync tasks and were verified to resync).

## Changes

### Item 10 — JacocoConfigurator helper reuse
Replaced 9 inline `jacocoConfig?.X?.getOrElse(...) ?: ...` expressions with calls to the four existing (previously unused outside tests) helpers `isEnabled`, `isHtmlReportEnabled`, `isXmlReportEnabled`, `getXmlReportFilename`. Textually identical expressions — zero behavior change; existing JacocoConfigurator tests pass unmodified.

### Item 11 — ConfigPlugin.configureRepositories
Replaced `getOrElse` fallbacks with `.get()`. All `Repositories` model properties always carry a convention (`property()` sets one from env / project property / default), so the fallbacks were unreachable. Note: the unreachable `sonatypeSnapshots.getOrElse(true)` fallback contradicted the model default (`false`) — `.get()` preserves actual runtime behavior.

### Item 12 — de-collide getArtifactId
Two unrelated same-signature functions renamed to say what they do:
- `PublishJvmSetup.getArtifactId` → `pluginMarkerArtifactId` (test updated for the rename only)
- `PublishMppSetup.getArtifactId` → `mppTargetArtifactId` (private)

### Item 13 — trivial dead weight
- Deleted the commented-out `codacy-analysis` job in `.github/workflows/sec-workflow.yml`
- Deleted the no-op `jsMain { dependencies { } }` block in `MppJsPlugin`
- Replaced the duplicated `:config`/`:plugin` Sync-task wiring in root `build.gradle.kts` with a loop (same tasks, same dependsOn edges)
- Dropped the stale `.gitignore` entry for the removed `dependencies/` module (verified: no such module in the tree or `settings.gradle.kts`)

### Item 14 — dead config surface (zero production readers, verified by grep)
Deleted, along with their own unit tests (each was referenced only by tests exercising the dead declaration itself):
- `Jacoco.mergeFrom` (mergeConfig omits jacoco — that omission is a known behavior-changing defect tracked separately, deliberately NOT fixed here)
- `Project.initListProperty` (PropertyUtils) + its test env var wiring in `build-composite/build.gradle.kts`
- `ExtensionContainer.fixersIfExists`
- `ConfigExtension.properties`
- `ConfigExtension.buildTime` (also removed from `toString`)

**Skipped: `Bundle.id` removal.** Re-verification found it is not dead: fixers-f2, fixers-s2 and fixers-c2 all set `bundle { id = ... }` in their root build scripts, so removal would break downstream builds as soon as the `-SNAPSHOT` propagates. Needs a deprecation cycle (Tier 3 treatment) instead.

## Verification
- `./gradlew build` — BUILD SUCCESSFUL (Sync tasks fired; regenerated `config/`/`plugin/` verified to contain the changes)
- `./gradlew :build-composite:test :plugin:test :config:test :integration-tests:test` — 319 tests, 0 failures
- `./gradlew :plugin:detekt :config:detekt --rerun-tasks` — BUILD SUCCESSFUL, no new suppressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - JaCoCo reporting configuration now consistently applies enabled-state, report-format, and XML filename settings.
  - Repository configuration now respects explicitly provided settings without automatically enabling Maven Central or adding fallback repositories.

- **Refactor**
  - Simplified Gradle task wiring and removed unused build configuration options.
  - Streamlined publication artifact naming and Kotlin Multiplatform setup.
  - Removed obsolete list-property and configuration helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->