### PR TITLE
refactor: tier 2 simplification — publish/kotlin plugin dedup

### DIFF
--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/kotlin/JvmPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/kotlin/JvmPlugin.kt
@@ -1,7 +1,5 @@
 package io.komune.fixers.gradle.plugin.kotlin
 
-import io.komune.fixers.gradle.config.fixers
-import io.komune.fixers.gradle.config.model.Jdk
 import io.komune.fixers.gradle.config.utils.configureJUnitPlatform
 import io.komune.fixers.gradle.plugin.config.ConfigPlugin
 import org.gradle.api.Plugin
@@ -16,8 +14,6 @@ import org.gradle.kotlin.dsl.kotlin
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
 @Suppress("UnstableApiUsage")
 class JvmPlugin : Plugin<Project> {
@@ -33,8 +29,7 @@ class JvmPlugin : Plugin<Project> {
 	private fun Project.configureJvmCompilation() {
 		logger.info("Configuring JVM compilation for project: $name")
 		plugins.apply(ConfigPlugin::class.java)
-		val fixersConfig = rootProject.extensions.fixers
-		val jdkVersion = fixersConfig?.jdk?.version?.orNull ?: Jdk.VERSION_DEFAULT
+		val jdkVersion = fixersJdkVersion()
 
 		logger.info("Using JDK version: $jdkVersion")
 
@@ -44,8 +39,7 @@ class JvmPlugin : Plugin<Project> {
 			compilerOptions {
 				freeCompilerArgs.add("-Xjsr305=strict")
 				jvmTarget.set(JvmTarget.fromTarget(jdkVersion.toString()))
-				val kotlinLangVersion = getKotlinPluginVersion().substringBeforeLast(".")
-				languageVersion.set(KotlinVersion.fromVersion(kotlinLangVersion))
+				languageVersion.set(kotlinLanguageVersion())
 			}
 		}
 

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/kotlin/KotlinVersionUtils.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/kotlin/KotlinVersionUtils.kt
@@ -1,0 +1,21 @@
+package io.komune.fixers.gradle.plugin.kotlin
+
+import io.komune.fixers.gradle.config.fixers
+import io.komune.fixers.gradle.config.model.Jdk
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+
+/**
+ * Resolves the JDK version from the root `fixers { jdk { version } }` configuration,
+ * falling back to [Jdk.VERSION_DEFAULT] when unset.
+ */
+internal fun Project.fixersJdkVersion(): Int =
+	rootProject.extensions.fixers?.jdk?.version?.orNull ?: Jdk.VERSION_DEFAULT
+
+/**
+ * Derives the Kotlin language version from the applied Kotlin plugin version
+ * (e.g. `2.2.10` -> `2.2`).
+ */
+internal fun Project.kotlinLanguageVersion(): KotlinVersion =
+	KotlinVersion.fromVersion(getKotlinPluginVersion().substringBeforeLast("."))

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/kotlin/MppPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/kotlin/MppPlugin.kt
@@ -1,7 +1,5 @@
 package io.komune.fixers.gradle.plugin.kotlin
 
-import io.komune.fixers.gradle.config.fixers
-import io.komune.fixers.gradle.config.model.Jdk
 import io.komune.fixers.gradle.config.utils.configureJUnitPlatform
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -9,8 +7,6 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
 class MppPlugin : Plugin<Project> {
 
@@ -41,8 +37,7 @@ class MppPlugin : Plugin<Project> {
 
 	private fun Project.setupJvmTarget() {
 		logger.info("Setting up JVM Target for project: $name")
-		val fixersConfig = rootProject.extensions.fixers
-		val jdkVersion = fixersConfig?.jdk?.version?.orNull ?: Jdk.VERSION_DEFAULT
+		val jdkVersion = fixersJdkVersion()
 		extensions.configure(KotlinMultiplatformExtension::class.java) {
 			jvm {
 				logger.info("Configuring JVM compilation with JDK version: $jdkVersion")
@@ -50,8 +45,7 @@ class MppPlugin : Plugin<Project> {
 					compileTaskProvider.configure {
 						compilerOptions {
 							jvmTarget.set(JvmTarget.fromTarget(jdkVersion.toString()))
-							val kotlinLangVersion = getKotlinPluginVersion().substringBeforeLast(".")
-							languageVersion.set(KotlinVersion.fromVersion(kotlinLangVersion))
+							languageVersion.set(kotlinLanguageVersion())
 						}
 					}
 				}

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublicationUtils.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublicationUtils.kt
@@ -1,0 +1,25 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import io.komune.fixers.gradle.config.utils.pom
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.create
+
+/**
+ * Creates the `maven` publication from the given software component if no publication
+ * with that name exists yet, applying the standard fixers POM from the bundle config.
+ */
+internal fun Project.createMavenPublicationIfAbsent(componentName: String, config: ConfigExtension) {
+	extensions.findByType(PublishingExtension::class.java)?.let { publishing ->
+		publishing.publications {
+			if (findByName("maven") == null) {
+				create<MavenPublication>("maven") {
+					from(components.findByName(componentName))
+					pom(project.pom(config.bundle))
+				}
+			}
+		}
+	}
+}

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishCatalogSetup.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishCatalogSetup.kt
@@ -1,31 +1,13 @@
 package io.komune.fixers.gradle.plugin.publish
 
 import io.komune.fixers.gradle.config.ConfigExtension
-import io.komune.fixers.gradle.config.utils.pom
 import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.create
 
 object PublishCatalogSetup {
 
 	fun setupCatalogPublish(project: Project, config: ConfigExtension) {
 		project.plugins.withId("version-catalog") {
-			project.setupCatalogPublication(config)
-		}
-	}
-
-	private fun Project.setupCatalogPublication(config: ConfigExtension) {
-		extensions.findByType(PublishingExtension::class.java)?.let { publishing ->
-			publishing.publications {
-				if (findByName("maven") == null) {
-					create<MavenPublication>("maven") {
-						from(components.findByName("versionCatalog"))
-						val publication = project.pom(config.bundle)
-						pom(publication)
-					}
-				}
-			}
+			project.createMavenPublicationIfAbsent("versionCatalog", config)
 		}
 	}
 }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetup.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishJvmSetup.kt
@@ -10,7 +10,6 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.the
 
@@ -48,18 +47,8 @@ object PublishJvmSetup {
 	}
 
 	private fun Project.setupPublication(config: ConfigExtension) {
-		project.extensions.findByType(PublishingExtension::class.java)?.let { publishing ->
-			extensions.findByType(JavaPluginExtension::class.java)?.let {
-				publishing.publications {
-					if (findByName("maven") == null) {
-						create<MavenPublication>("maven") {
-							from(components["kotlin"])
-							val publication = project.pom(config.bundle)
-							pom(publication)
-						}
-					}
-				}
-			}
+		extensions.findByType(JavaPluginExtension::class.java)?.let {
+			createMavenPublicationIfAbsent("kotlin", config)
 		}
 	}
 

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlatformSetup.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlatformSetup.kt
@@ -1,32 +1,14 @@
 package io.komune.fixers.gradle.plugin.publish
 
 import io.komune.fixers.gradle.config.ConfigExtension
-import io.komune.fixers.gradle.config.utils.pom
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlatformPlugin
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.create
 
 object PublishPlatformSetup {
 
 	fun setupPlatformPublish(project: Project, config: ConfigExtension) {
 		project.plugins.withType(JavaPlatformPlugin::class.java) {
-			project.setupPlatformPublication(config)
-		}
-	}
-
-	private fun Project.setupPlatformPublication(config: ConfigExtension) {
-		extensions.findByType(PublishingExtension::class.java)?.let { publishing ->
-			publishing.publications {
-				if (findByName("maven") == null) {
-					create<MavenPublication>("maven") {
-						from(components.findByName("javaPlatform"))
-						val publication = project.pom(config.bundle)
-						pom(publication)
-					}
-				}
-			}
+			project.createMavenPublicationIfAbsent("javaPlatform", config)
 		}
 	}
 }

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/PublishPlugin.kt
@@ -5,9 +5,13 @@ import io.komune.fixers.gradle.config.fixers
 import io.komune.fixers.gradle.config.model.PublishConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
@@ -179,7 +183,35 @@ class PublishPlugin : Plugin<Project> {
 		}
 	}
 
-	@Suppress("LongMethod", "ThrowsCount")
+	private fun registerCleanStagingTask(
+		root: Project,
+		stagingDirProvider: Provider<Directory>,
+		publishSubprojects: List<Project>
+	): TaskProvider<Task> {
+		val cleanStagingTask = root.tasks.register("cleanStaging") {
+			group = "publishing"
+			description = "Cleans the staging directory before publishing"
+			doLast {
+				stagingDirProvider.get().asFile.deleteRecursively()
+			}
+		}
+
+		// Ensure ALL publish-to-staging tasks run after cleanStaging.
+		// publishAllPublicationsToStagingRepository is just an aggregate — the actual file writes
+		// happen in individual tasks (publishXPublicationToStagingRepository). With parallel=true,
+		// those individual tasks can race with cleanStaging's deleteRecursively(), causing partial
+		// staging directories (some files deleted mid-write). Matching all publish*ToStagingRepository
+		// tasks prevents this race condition.
+		publishSubprojects.forEach { subproject ->
+			subproject.tasks.matching {
+				it.name.startsWith("publish") && it.name.endsWith("ToStagingRepository")
+			}.configureEach {
+				mustRunAfter(cleanStagingTask)
+			}
+		}
+		return cleanStagingTask
+	}
+
 	private fun registerPublishTasks(
 		root: Project,
 		fixersConfig: ConfigExtension,
@@ -202,27 +234,7 @@ class PublishPlugin : Plugin<Project> {
 		val centralPollTimeoutProvider = fixersConfig.publish.mavenCentralStatusPollTimeoutSeconds
 		val bundleName = "${root.name}-$version"
 
-		val cleanStagingTask = root.tasks.register("cleanStaging") {
-			group = "publishing"
-			description = "Cleans the staging directory before publishing"
-			doLast {
-				stagingDirProvider.get().asFile.deleteRecursively()
-			}
-		}
-
-		// Ensure ALL publish-to-staging tasks run after cleanStaging.
-		// publishAllPublicationsToStagingRepository is just an aggregate — the actual file writes
-		// happen in individual tasks (publishXPublicationToStagingRepository). With parallel=true,
-		// those individual tasks can race with cleanStaging's deleteRecursively(), causing partial
-		// staging directories (some files deleted mid-write). Matching all publish*ToStagingRepository
-		// tasks prevents this race condition.
-		publishSubprojects.forEach { subproject ->
-			subproject.tasks.matching {
-				it.name.startsWith("publish") && it.name.endsWith("ToStagingRepository")
-			}.configureEach {
-				mustRunAfter(cleanStagingTask)
-			}
-		}
+		val cleanStagingTask = registerCleanStagingTask(root, stagingDirProvider, publishSubprojects)
 
 		// Stage: publish to staging directory, then upload to GitHub Packages
 		// Uses custom uploader to handle 409 Conflict (already-published artifacts) gracefully.
@@ -239,17 +251,15 @@ class PublishPlugin : Plugin<Project> {
 		// Promote: route based on version type
 		root.tasks.register("promote") {
 			group = "publishing"
+			dependsOn(cleanStagingTask)
+			dependsOn(allPublishToStagingTasks)
 			if (isSnapshot) {
 				description = "Publishes all SNAPSHOT artifacts to Maven Central Snapshots"
-				dependsOn(cleanStagingTask)
-				dependsOn(allPublishToStagingTasks)
 				doLast {
 					uploadToMavenSnapshots(stagingDirProvider.get().asFile, fixersConfig)
 				}
 			} else {
 				description = "Publishes all artifacts to Maven Central via Central Portal"
-				dependsOn(cleanStagingTask)
-				dependsOn(allPublishToStagingTasks)
 
 				// Also publish to Gradle Plugin Portal (only non-SNAPSHOT releases are accepted)
 				if (fixersConfig.publish.gradlePluginPortalEnabled.getOrElse(true)) {
@@ -275,55 +285,6 @@ class PublishPlugin : Plugin<Project> {
 		}
 	}
 
-	private fun uploadToGithubPackages(stagingDir: java.io.File, fixersConfig: ConfigExtension) {
-		val ghUsername = fixersConfig.publish.pkgGithubUsername.orNull
-			?: throw org.gradle.api.GradleException(
-				"FIXERS_PUBLISH_GITHUB_USERNAME is not set"
-			)
-		val ghToken = fixersConfig.publish.pkgGithubToken.orNull
-			?: throw org.gradle.api.GradleException(
-				"FIXERS_PUBLISH_GITHUB_TOKEN is not set"
-			)
-		MavenRepositoryUploader.to("GitHub Packages")
-			.from(stagingDir)
-			.at(fixersConfig.publish.githubPackagesUrl.get())
-			.withCredentials(ghUsername, ghToken)
-			.upload()
-	}
-
-	private fun uploadToMavenSnapshots(stagingDir: java.io.File, fixersConfig: ConfigExtension) {
-		val username = fixersConfig.publish.mavenCentralUsername.orNull
-			?: throw org.gradle.api.GradleException("FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME is not set")
-		val password = fixersConfig.publish.mavenCentralPassword.orNull
-			?: throw org.gradle.api.GradleException("FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD is not set")
-		MavenRepositoryUploader.to("Maven Central Snapshots")
-			.from(stagingDir)
-			.at(fixersConfig.publish.mavenSnapshotsUrl.get())
-			.withCredentials(username, password)
-			.upload()
-	}
-
-	private fun uploadToCentralPortal(
-		stagingDir: java.io.File,
-		centralUrl: String,
-		username: String?,
-		password: String?,
-		bundleName: String,
-		options: CentralPortalUploader.Options,
-	) {
-		val resolvedUsername = username
-			?: throw org.gradle.api.GradleException("FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME is not set")
-		val resolvedPassword = password
-			?: throw org.gradle.api.GradleException("FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD is not set")
-		CentralPortalUploader.upload(
-			stagingDir = stagingDir,
-			baseUrl = centralUrl,
-			username = resolvedUsername,
-			password = resolvedPassword,
-			bundleName = bundleName,
-			options = options,
-		)
-	}
 }
 
 /**

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/StagingUploads.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/publish/StagingUploads.kt
@@ -1,0 +1,62 @@
+package io.komune.fixers.gradle.plugin.publish
+
+import io.komune.fixers.gradle.config.ConfigExtension
+import java.io.File
+import org.gradle.api.GradleException
+
+internal fun uploadToGithubPackages(stagingDir: File, fixersConfig: ConfigExtension) = uploadTo(
+	repositoryName = "GitHub Packages",
+	stagingDir = stagingDir,
+	url = fixersConfig.publish.githubPackagesUrl.get(),
+	username = requireCredential(fixersConfig.publish.pkgGithubUsername.orNull, "FIXERS_PUBLISH_GITHUB_USERNAME"),
+	password = requireCredential(fixersConfig.publish.pkgGithubToken.orNull, "FIXERS_PUBLISH_GITHUB_TOKEN"),
+)
+
+internal fun uploadToMavenSnapshots(stagingDir: File, fixersConfig: ConfigExtension) = uploadTo(
+	repositoryName = "Maven Central Snapshots",
+	stagingDir = stagingDir,
+	url = fixersConfig.publish.mavenSnapshotsUrl.get(),
+	username = requireCredential(
+		fixersConfig.publish.mavenCentralUsername.orNull, "FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME"
+	),
+	password = requireCredential(
+		fixersConfig.publish.mavenCentralPassword.orNull, "FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD"
+	),
+)
+
+internal fun uploadToCentralPortal(
+	stagingDir: File,
+	centralUrl: String,
+	username: String?,
+	password: String?,
+	bundleName: String,
+	options: CentralPortalUploader.Options,
+) {
+	val resolvedUsername = requireCredential(username, "FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME")
+	val resolvedPassword = requireCredential(password, "FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD")
+	CentralPortalUploader.upload(
+		stagingDir = stagingDir,
+		baseUrl = centralUrl,
+		username = resolvedUsername,
+		password = resolvedPassword,
+		bundleName = bundleName,
+		options = options,
+	)
+}
+
+private fun requireCredential(value: String?, envVar: String): String =
+	value ?: throw GradleException("$envVar is not set")
+
+private fun uploadTo(
+	repositoryName: String,
+	stagingDir: File,
+	url: String,
+	username: String,
+	password: String,
+) {
+	MavenRepositoryUploader.to(repositoryName)
+		.from(stagingDir)
+		.at(url)
+		.withCredentials(username, password)
+		.upload()
+}


### PR DESCRIPTION
Tier 2 (items 37–39) of the simplification audit. **Behavior-preserving only**, all edits in `build-composite/` (generated `config/`/`plugin/` trees regenerate via Sync tasks — verified in sync after build).

## Item 37 — shared maven publication creation
- New `Project.createMavenPublicationIfAbsent(componentName, config)` in `plugin/publish/PublicationUtils.kt`.
- Used by `PublishPlatformSetup` (`withType(JavaPlatformPlugin)` → `javaPlatform`), `PublishCatalogSetup` (`withId("version-catalog")` → `versionCatalog`), `PublishJvmSetup` (`kotlin` component, `JavaPluginExtension` guard kept).
- Each trigger, the `findByName("maven") == null` guard, `from(component)`, and `pom(project.pom(bundle))` preserved exactly; the three setup objects stay.

## Item 38 — PublishPlugin promote/upload dedup
- Hoisted the duplicated `dependsOn(cleanStagingTask); dependsOn(allPublishToStagingTasks)` pair above the snapshot/release `if` in `promote`.
- Collapsed `uploadToGithubPackages`/`uploadToMavenSnapshots` into shared `uploadTo(...)` + `requireCredential(value, envVar)`; exact `GradleException` messages naming each env var kept (`FIXERS_PUBLISH_GITHUB_USERNAME/TOKEN`, `FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME/PASSWORD`). `uploadToCentralPortal` reuses the same guard.
- Upload helpers moved to `StagingUploads.kt` (same package, `internal`); `registerCleanStagingTask` extracted (cleanStaging registration + the staging-race `mustRunAfter` wiring, comment kept).
- **`@Suppress("LongMethod", "ThrowsCount")` removed** — detekt passes without it; no new suppressions anywhere.

## Item 39 — shared JDK/Kotlin version resolution
- New `Project.fixersJdkVersion()` and `Project.kotlinLanguageVersion()` in `plugin/kotlin/KotlinVersionUtils.kt`, replacing the duplicated resolution in `JvmPlugin`/`MppPlugin` (`rootProject.extensions.fixers?.jdk?.version?.orNull ?: Jdk.VERSION_DEFAULT`; `KotlinVersion.fromVersion(getKotlinPluginVersion().substringBeforeLast("."))`). Identical resolution order and call sites.

## Verification
- `./gradlew build` green; regenerated `config/`/`plugin/` trees diffed against `build-composite/` — in sync, edits carried.
- `./gradlew detekt` green (with the suppressions removed).
- Full test suite rerun (`--rerun-tasks`): **37 tests, 0 failures** — including `PublishPluginIntegrationTest` (6/6), `PublishStagingIntegrationTest` (1/1), `KotlinJvmPluginIntegrationTest`, `KotlinMppPluginIntegrationTest`.

Plan ref: fixers-f2 `docs/simplification-audit-plan.md` Tier 2 items 37–39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JVM and multiplatform builds by consistently deriving JDK and Kotlin language versions from project configuration.

* **Publishing**
  * Standardized Maven publication setup across catalogs, JVM libraries, and platform modules.
  * Improved staging cleanup and task ordering for snapshot and release publishing.
  * Added clearer validation for missing publishing credentials.
  * Streamlined uploads to GitHub Packages, Maven Central Snapshots, and the Maven Central Portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->