### PR TITLE
fix: merge root jacoco config into subprojects (ConfigPlugin.mergeConfig)

### DIFF
--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/Jacoco.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/config/model/Jacoco.kt
@@ -1,5 +1,6 @@
 package io.komune.fixers.gradle.config.model
 
+import io.komune.fixers.gradle.config.utils.mergeIfNotPresent
 import io.komune.fixers.gradle.config.utils.property
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -54,6 +55,23 @@ class Jacoco(
         projectKey = "fixers.jacoco.version",
         defaultValue = FixersToolVersions.jacoco
     )
+
+    /**
+     * Merges properties from the source Jacoco into this Jacoco.
+     * Properties are only merged if the target property is not present and the source property is present.
+     *
+     * @param source The source Jacoco to merge from
+     * @return This Jacoco after merging
+     */
+    fun mergeFrom(source: Jacoco): Jacoco {
+        enabled.mergeIfNotPresent(source.enabled)
+        htmlReport.mergeIfNotPresent(source.htmlReport)
+        xmlReport.mergeIfNotPresent(source.xmlReport)
+        xmlReportFilename.mergeIfNotPresent(source.xmlReportFilename)
+        version.mergeIfNotPresent(source.version)
+
+        return this
+    }
 
     companion object {
         const val DEFAULT_XML_REPORT_FILENAME = "jacocoTestReport.xml"

--- a/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/config/ConfigPlugin.kt
+++ b/build-composite/src/main/kotlin/io/komune/fixers/gradle/plugin/config/ConfigPlugin.kt
@@ -82,6 +82,7 @@ class ConfigPlugin : Plugin<Project> {
         subprojectConfig.bundle.mergeFrom(rootConfig.bundle)
         subprojectConfig.publish.mergeFrom(rootConfig.publish)
         subprojectConfig.detekt.mergeFrom(rootConfig.detekt)
+        subprojectConfig.jacoco.mergeFrom(rootConfig.jacoco)
         subprojectConfig.jdk.mergeFrom(rootConfig.jdk)
         subprojectConfig.kt2Ts.mergeFrom(rootConfig.kt2Ts)
         subprojectConfig.npm.mergeFrom(rootConfig.npm)

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/model/ConfigModelsTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/config/model/ConfigModelsTest.kt
@@ -112,6 +112,40 @@ class ConfigModelsTest {
     }
 
     @Nested
+    inner class JacocoModelTest {
+
+        @Test
+        fun `should have reports enabled by default`() {
+            val jacoco = Jacoco(project)
+
+            assertThat(jacoco.enabled.get()).isTrue()
+            assertThat(jacoco.htmlReport.get()).isTrue()
+            assertThat(jacoco.xmlReport.get()).isTrue()
+            assertThat(jacoco.xmlReportFilename.get()).isEqualTo(Jacoco.DEFAULT_XML_REPORT_FILENAME)
+            assertThat(jacoco.version.get()).isNotBlank()
+        }
+
+        @Test
+        fun `should not override convention-backed values on merge`() {
+            // All properties have conventions, so isPresent is always true and
+            // mergeIfNotPresent keeps the target values (same contract as Repositories).
+            val source = Jacoco(project).apply {
+                enabled.set(false)
+                xmlReportFilename.set("source.xml")
+            }
+            val target = Jacoco(project).apply {
+                xmlReportFilename.set("target.xml")
+            }
+
+            val merged = target.mergeFrom(source)
+
+            assertThat(merged).isSameAs(target)
+            assertThat(target.enabled.get()).isTrue()
+            assertThat(target.xmlReportFilename.get()).isEqualTo("target.xml")
+        }
+    }
+
+    @Nested
     inner class JdkModelTest {
 
         @Test

--- a/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/config/ConfigPluginTest.kt
+++ b/build-composite/src/test/kotlin/io/komune/fixers/gradle/plugin/config/ConfigPluginTest.kt
@@ -101,6 +101,19 @@ class ConfigPluginTest {
         }
 
         @Test
+        fun `should keep subproject jacoco overrides when merging root config`() {
+            val root = ProjectBuilder.builder().build()
+            val child = ProjectBuilder.builder().withParent(root).build()
+            root.plugins.apply(ConfigPlugin::class.java)
+            root.extensions.fixers!!.jacoco.xmlReportFilename.set("root.xml")
+            child.config().jacoco.xmlReportFilename.set("child.xml")
+
+            fireProjectsEvaluated(root)
+
+            assertThat(child.extensions.fixers!!.jacoco.xmlReportFilename.get()).isEqualTo("child.xml")
+        }
+
+        @Test
         fun `should configure maven central repository by default`() {
             val root = ProjectBuilder.builder().build()
             root.plugins.apply(ConfigPlugin::class.java)


### PR DESCRIPTION
Defect from the simplification audit: `ConfigPlugin.mergeConfig` propagates 9 of the 10 fixers config models from the root project to subprojects — `jacoco` was silently omitted. `Jacoco.mergeFrom` had existed for exactly this purpose and was deleted as dead code in #238, which confirms the omission was an oversight rather than a decision.

## Change
- Reintroduce a minimal `Jacoco.mergeFrom(source)` — `mergeIfNotPresent` per property (`enabled`, `htmlReport`, `xmlReport`, `xmlReportFilename`, `version`), identical in shape to the deleted original and to the 9 sibling models.
- Call it from `ConfigPlugin.mergeConfig`.

## Behaviour impact — please read, it is narrower than the audit assumed
The audit filed this as a behaviour change ("subprojects start inheriting root jacoco config"). Reading the code and probing it empirically, **there is no observable change in a real build**:

1. **The merge cannot fire.** Every `Jacoco` property carries a convention (`enabled`/`htmlReport`/`xmlReport` = true, `xmlReportFilename` = `jacocoTestReport.xml`, `version` = the pinned toolchain version), so `isPresent` is always true and `mergeIfNotPresent` is a no-op. Probed on a root+subproject build: with root `jacoco { enabled = false; xmlReportFilename = "custom.xml" }`, the subproject model still resolves to `true` / `jacocoTestReport.xml` after the merge. Same latent property as the existing `Repositories` merge test documents.
2. **Root jacoco already governs subprojects anyway.** `CheckPlugin` reads `target.rootProject.extensions.fixers` and hands *that* `Jacoco` model to a `JacocoConfigurator` for each subproject — the subproject's own model is never read.

So this PR closes a model asymmetry and guards any future `Jacoco` property added without a convention; it does not change what any current build does. No downstream (`f2`/`s2`/`c2`) impact via `-SNAPSHOT`.

## Follow-up worth a separate decision (not done here)
Because of (2), a **subproject-level `fixers { jacoco { ... } }` block is silently ignored today**. Making it effective needs `CheckPlugin` to read each subproject's model *plus* explicit-set-aware inheritance (e.g. `convention(rootProperty)` instead of `mergeIfNotPresent`) — otherwise root-level settings would be clobbered by subproject conventions. That trade-off applies to all 10 models equally and deserves its own design pass.

## Tests
- `ConfigModelsTest.JacocoModelTest`: defaults, and `mergeFrom` contract (returns `this`, does not overwrite target values) — new coverage for the reintroduced function.
- `ConfigPluginTest`: `mergeConfig` must not clobber a subproject's own `jacoco` override.

## Verification
- `./gradlew build detekt` green (generated `config/`/`plugin/` trees re-synced; `jacoco.mergeFrom` present in generated `plugin/`).
- build-composite: 285/285 tests green (full `--rerun-tasks`); `plugin` integration suite 36/36 green.

Do not merge without review.